### PR TITLE
Fix API endpoint concatenation

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -5,9 +5,10 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.action === 'translate') {
     const { endpoint, apiKey, model, text, target } = msg.opts;
+    const ep = endpoint.endsWith('/') ? endpoint : `${endpoint}/`;
     const controller = new AbortController();
     const timer = setTimeout(() => controller.abort(), 10000);
-    const url = `${endpoint}services/aigc/mt/text-translator/generation`;
+    const url = `${ep}services/aigc/mt/text-translator/generation`;
     console.log('Background translating via', url);
     fetch(url, {
       method: 'POST',

--- a/src/options.js
+++ b/src/options.js
@@ -27,9 +27,13 @@ function attachSearch(select, input) {
   });
 }
 
+function withSlash(url) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
 async function fetchModels() {
-  const endpoint = endpointInput.value;
-  const key = apiKeyInput.value;
+  const endpoint = withSlash(endpointInput.value.trim());
+  const key = apiKeyInput.value.trim();
   try {
     const url = `${endpoint}services/aigc/mt/text-translator/models`;
     console.log('Fetching models from', url);
@@ -78,7 +82,7 @@ window.qwenLoadConfig().then(cfg => {
 document.getElementById('save').addEventListener('click', () => {
   const cfg = {
     apiKey: apiKeyInput.value.trim(),
-    apiEndpoint: endpointInput.value.trim(),
+    apiEndpoint: withSlash(endpointInput.value.trim()),
     model: modelSelect.value,
     targetLanguage: targetSelect.value,
     ignoredLanguages: [...ignoredSelect.selectedOptions].map(o => o.value),

--- a/src/translator.js
+++ b/src/translator.js
@@ -5,8 +5,12 @@ if (typeof window === 'undefined') {
 
 const cache = new Map();
 
+function withSlash(url) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
 async function doFetch({ endpoint, apiKey, model, text, target, signal }) {
-  const url = `${endpoint}services/aigc/mt/text-translator/generation`;
+  const url = `${withSlash(endpoint)}services/aigc/mt/text-translator/generation`;
   console.log('Sending translation request to', url);
   const body = {
     model,
@@ -41,9 +45,10 @@ async function qwenTranslate({ endpoint, apiKey, model, text, target, signal }) 
   }
 
   if (typeof chrome !== 'undefined' && chrome.runtime && chrome.runtime.sendMessage) {
+    const ep = withSlash(endpoint);
     const result = await new Promise((resolve, reject) => {
       console.log('Requesting translation via background script');
-      chrome.runtime.sendMessage({ action: 'translate', opts: { endpoint, apiKey, model, text, target } }, res => {
+      chrome.runtime.sendMessage({ action: 'translate', opts: { endpoint: ep, apiKey, model, text, target } }, res => {
         if (chrome.runtime.lastError) {
           reject(new Error(chrome.runtime.lastError.message));
         } else if (res && res.error) {


### PR DESCRIPTION
## Summary
- keep API endpoints well-formed by ensuring trailing slashes
- use helper for options page and background requests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688a27db1494832398a316b7537f45c4