### PR TITLE
Add streaming command line translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,13 @@ Run the unit tests with:
 npm install
 npm test
 ```
+
+## Command Line Utility
+A simple translator CLI is included in `cli/translate.js`. It streams translations as you type.
+
+### Usage
+```sh
+node cli/translate.js -k <API_KEY> [-e endpoint] [-m model] -s <source_lang> -t <target_lang>
+```
+Press `Ctrl+C` or `Ctrl+D` to exit.
+

--- a/cli/translate.js
+++ b/cli/translate.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+const readline = require('readline');
+const fetch = require('cross-fetch');
+
+function withSlash(url) {
+  return url.endsWith('/') ? url : `${url}/`;
+}
+
+async function translateStream({ endpoint, apiKey, model, text, source, target }, onData) {
+  const url = `${withSlash(endpoint)}services/aigc/mt/text-translator/generation-stream`;
+  const body = { model, input: { source_language: source, target_language: target, text } };
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({ message: resp.statusText }));
+    throw new Error(`HTTP ${resp.status}: ${err.message || 'Translation failed'}`);
+  }
+
+  if (!resp.body || typeof resp.body.getReader !== 'function') {
+    const data = await resp.json();
+    if (data.output && data.output.text) onData(data.output.text);
+    return;
+  }
+
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop();
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data:')) continue;
+      const data = trimmed.slice(5).trim();
+      if (data === '[DONE]') {
+        reader.cancel();
+        return;
+      }
+      try {
+        const obj = JSON.parse(data);
+        if (obj.output && obj.output.text) onData(obj.output.text);
+      } catch {}
+    }
+  }
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const opts = {};
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '-k' || a === '--key') opts.apiKey = args[++i];
+    else if (a === '-e' || a === '--endpoint') opts.endpoint = args[++i];
+    else if (a === '-m' || a === '--model') opts.model = args[++i];
+    else if (a === '-s' || a === '--source') opts.source = args[++i];
+    else if (a === '-t' || a === '--target') opts.target = args[++i];
+    else if (a === '-h' || a === '--help') opts.help = true;
+  }
+  return opts;
+}
+
+async function main() {
+  const DEFAULT_ENDPOINT = 'https://dashscope.aliyuncs.com';
+  const DEFAULT_MODEL = 'qwen-mt-turbo';
+  const opts = parseArgs();
+
+  if (opts.help || !opts.apiKey || !opts.source || !opts.target) {
+    console.log('Usage: node translate.js -k <apiKey> [-e endpoint] [-m model] -s <source> -t <target>');
+    process.exit(opts.help ? 0 : 1);
+  }
+
+  opts.endpoint = opts.endpoint || DEFAULT_ENDPOINT;
+  opts.model = opts.model || DEFAULT_MODEL;
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout, prompt: '> ' });
+  rl.prompt();
+  rl.on('line', async line => {
+    line = line.trim();
+    if (!line) { rl.prompt(); return; }
+    try {
+      await translateStream({ ...opts, text: line }, chunk => process.stdout.write(chunk));
+      process.stdout.write('\n');
+    } catch (err) {
+      console.error(err.stack || err.toString());
+      process.exit(1);
+    }
+    rl.prompt();
+  });
+
+  rl.on('close', () => {
+    console.log('');
+    process.exit(0);
+  });
+}
+
+main().catch(err => {
+  console.error(err.stack || err.toString());
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add `translate.js` CLI for real‑time translation using the streaming API
- document new CLI usage in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a3fc8b4fc83239c24439780983d67