### PR TITLE
Improve extension status UI and server headers

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,7 +9,7 @@ const config = {
   },
   testDir: 'e2e',
   webServer: {
-    command: 'npx http-server -p 8080 -c-1 .',
+    command: "npx http-server -p 8080 -c-1 . -H 'Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=(), camera=()'",
     url: 'http://127.0.0.1:8080',
     reuseExistingServer: true,
     timeout: 120000

--- a/src/background.js
+++ b/src/background.js
@@ -62,28 +62,24 @@ async function updateIcon() {
   ctx.clearRect(0, 0, 19, 19);
   ctx.fillStyle = '#fff';
   ctx.fillRect(0, 0, 19, 19);
-  const pulse = 0.6 + 0.4 * Math.sin(iconFrame / 3);
-  if (activeTranslations > 0) {
-    ctx.strokeStyle = `rgba(13,110,253,${pulse})`;
-    ctx.lineWidth = 2;
-    ctx.strokeRect(1, 1, 17, 17);
-  } else {
-    ctx.strokeStyle = '#999';
-    ctx.lineWidth = 1;
-    ctx.strokeRect(0, 0, 19, 19);
-  }
-  // draw usage bars
+  const pulse = activeTranslations > 0 ? 0.6 + 0.4 * Math.sin(iconFrame / 3) : 1;
+  ctx.strokeStyle = activeTranslations > 0 ? `rgba(13,110,253,${pulse})` : '#ccc';
+  ctx.lineWidth = activeTranslations > 0 ? 2 : 1;
+  ctx.beginPath();
+  ctx.arc(9.5, 9.5, 8, 0, Math.PI * 2);
+  ctx.stroke();
+  // usage rings
   const blink = iconFrame % 20 < 10;
-  const barH = 14;
-  ctx.strokeStyle = '#ccc';
-  ctx.strokeRect(2, 3, 5, barH);
-  ctx.strokeRect(12, 3, 5, barH);
-  const reqH = Math.round(barH * reqPct);
-  ctx.fillStyle = requestLimit - requests <= 0 && blink ? '#fff' : reqColor;
-  ctx.fillRect(2, 3 + (barH - reqH), 5, reqH);
-  const tokH = Math.round(barH * tokPct);
-  ctx.fillStyle = tokenLimit - tokens <= 0 && blink ? '#fff' : tokColor;
-  ctx.fillRect(12, 3 + (barH - tokH), 5, tokH);
+  ctx.lineCap = 'round';
+  ctx.lineWidth = 3;
+  ctx.strokeStyle = requestLimit - requests <= 0 && blink ? '#fff' : reqColor;
+  ctx.beginPath();
+  ctx.arc(9.5, 9.5, 6, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * reqPct);
+  ctx.stroke();
+  ctx.strokeStyle = tokenLimit - tokens <= 0 && blink ? '#fff' : tokColor;
+  ctx.beginPath();
+  ctx.arc(9.5, 9.5, 3, -Math.PI / 2, -Math.PI / 2 + 2 * Math.PI * tokPct);
+  ctx.stroke();
   const imageData = ctx.getImageData(0, 0, 19, 19);
   chrome.action.setIcon({ imageData: { 19: imageData } });
 }

--- a/src/popup.html
+++ b/src/popup.html
@@ -5,7 +5,8 @@
   <style>
     body {
       font-family: system-ui, sans-serif;
-      width: 260px;
+      width: 300px;
+      min-height: 520px;
       padding: 12px;
       margin: 0;
       background: #fff;
@@ -37,11 +38,21 @@
       cursor: pointer;
     }
     button:hover { background: #1565c0; }
+    .buttons {
+      display: flex;
+      gap: 8px;
+    }
+    .buttons button { flex: 1; }
     #status {
       margin-top: 8px;
       font-size: 12px;
       color: #555;
-      min-height: 16px;
+      min-height: 40px;
+      max-height: 120px;
+      overflow-y: auto;
+      border: 1px solid #ccc;
+      padding: 4px;
+      background: #fafafa;
     }
     #usage {
       margin-top: 12px;
@@ -78,6 +89,11 @@
   <label>Tokens per minute <input type="number" id="tokenLimit"></label>
   <label><input type="checkbox" id="auto"> Translate automatically</label>
   <label><input type="checkbox" id="debug"> Debug logging</label>
+  <div class="buttons">
+    <button id="save">Save</button>
+    <button id="test">Test Settings</button>
+  </div>
+  <div id="status"></div>
   <div id="usage">
     <div>Requests <span id="reqCount">0/0</span></div>
     <div class="bar"><div id="reqBar"></div></div>
@@ -87,9 +103,6 @@
     <div>Total Tokens <span id="totalTok">0</span></div>
     <div>Queue <span id="queueLen">0</span></div>
   </div>
-  <button id="save">Save</button>
-  <button id="test">Test Settings</button>
-  <div id="status"></div>
   <div id="version"></div>
   <script src="throttle.js"></script>
   <script src="translator.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -17,6 +17,13 @@ const totalReq = document.getElementById('totalReq');
 const totalTok = document.getElementById('totalTok');
 const queueLen = document.getElementById('queueLen');
 
+function safeFetch(url, opts) {
+  return fetch(url, opts).catch(err => {
+    console.warn('Failed to fetch', url, err.message);
+    throw err;
+  });
+}
+
 function populateLanguages() {
   window.qwenLanguages.forEach(l => {
     const opt = document.createElement('option');
@@ -74,6 +81,10 @@ document.getElementById('translate').addEventListener('click', () => {
 });
 
 document.getElementById('save').addEventListener('click', () => {
+  if (!window.qwenSaveConfig) {
+    status.textContent = 'Config library not loaded. This may happen if the script was blocked.';
+    return;
+  }
   const cfg = {
     apiKey: apiKeyInput.value.trim(),
     apiEndpoint: endpointInput.value.trim(),
@@ -93,6 +104,10 @@ document.getElementById('save').addEventListener('click', () => {
 
 document.getElementById('test').addEventListener('click', async () => {
   status.textContent = 'Testing...';
+  if (!window.qwenTranslate || !window.qwenTranslateStream) {
+    status.textContent = 'Translation library not loaded. This may happen if the script was blocked.';
+    return;
+  }
   const list = document.createElement('ul');
   list.style.margin = '0';
   list.style.paddingLeft = '20px';
@@ -133,7 +148,7 @@ document.getElementById('test').addEventListener('click', async () => {
     const controller = new AbortController();
     const t = setTimeout(() => controller.abort(), 5000);
     try {
-      await fetch(cfg.endpoint, { method: 'GET', signal: controller.signal });
+      await safeFetch(cfg.endpoint, { method: 'GET', signal: controller.signal });
     } finally { clearTimeout(t); }
   })) && allOk;
 
@@ -143,7 +158,7 @@ document.getElementById('test').addEventListener('click', async () => {
     const controller = new AbortController();
     const t = setTimeout(() => controller.abort(), 5000);
     try {
-      await fetch(transUrl, { method: 'OPTIONS', signal: controller.signal });
+      await safeFetch(transUrl, { method: 'OPTIONS', signal: controller.signal });
     } finally { clearTimeout(t); }
   })) && allOk;
 


### PR DESCRIPTION
## Summary
- Redesign extension icon with animated rings showing rate-limit usage and active translation state
- Rework popup layout to expose Save/Test buttons and show test output clearly
- Add defensive checks around optional libraries and network fetches
- Serve test pages with a minimal Permissions-Policy header to quiet warnings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899de90c8388323be7f62816273ce0b