### PR TITLE
Fix e2e smoke tests and simple engine

### DIFF
--- a/src/qa/engine-smoke.html
+++ b/src/qa/engine-smoke.html
@@ -17,8 +17,9 @@
     import * as engine from '../wasm/engine.js';
     // Mock translator: identity mapping to avoid network
     window.qwenTranslateBatch = async ({ texts }) => ({ texts });
-    // pdf.js worker
+    // pdf.js worker (disabled due to file:// restrictions in tests)
     pdfjsLib.GlobalWorkerOptions.workerSrc = '../pdf.worker.min.js';
+    pdfjsLib.disableWorker = true;
 
     const qs = new URLSearchParams(location.search);
     const eng = qs.get('engine') || 'simple';
@@ -26,9 +27,9 @@
     const out = document.getElementById('out');
 
     async function makePdf(bytes) {
-      const doc = await pdfLib.PDFDocument.create();
+      const doc = await PDFLib.PDFDocument.create();
       const page = doc.addPage([400, 300]);
-      const font = await doc.embedFont(pdfLib.StandardFonts.Helvetica);
+      const font = await doc.embedFont(PDFLib.StandardFonts.Helvetica);
       const txt = 'Hello engine test';
       page.drawText(txt, { x: 50, y: 150, size: 18, font });
       return await doc.save();

--- a/src/wasm/vendor/simple.engine.js
+++ b/src/wasm/vendor/simple.engine.js
@@ -167,19 +167,23 @@ export async function init({ baseURL }) {
     const translatedBlocks = await translateChunks(pagesText);
 
     // Wrap translated text into lines per page
-    const wrappedPages = pagesText.map((p, idx) => ({
+    const wrappedPages = pagesText.map((p, idx) => {
       const block = (translatedBlocks[idx] || '').trim();
       const words = block.split(/\s+/);
       const maxChars = 90; // rough wrap target
       const lines = [];
       let cur = '';
       for (const w of words) {
-        if ((cur + ' ' + w).trim().length > maxChars) { lines.push(cur.trim()); cur = w; }
-        else { cur = (cur ? cur + ' ' : '') + w; }
+        if ((cur + ' ' + w).trim().length > maxChars) {
+          lines.push(cur.trim());
+          cur = w;
+        } else {
+          cur = (cur ? cur + ' ' : '') + w;
+        }
       }
       if (cur) lines.push(cur);
-      return { width: p.width, height: p.height, text: (translated[idx]||'').trim() };
-    }));
+      return { width: p.width, height: p.height, lines };
+    });
 
     const blob = await buildSimplePdf(wrappedPages, onProgress);
     return blob;


### PR DESCRIPTION
## Summary
- fix simple engine PDF page wrapping
- load pdf-lib correctly and disable pdf.js worker for file URLs
- e2e smoke tests now start HTTP server when available

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6899e7fb50b483239c827e1ed0ef6165