### PR TITLE
fix: load wasm fonts and darken settings

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -38,7 +38,7 @@
         "wasm/vendor/mupdf.engine.js", "wasm/vendor/mupdf.wasm",
         "wasm/vendor/pdfium.engine.js", "wasm/vendor/pdfium.js", "wasm/vendor/pdfium.wasm",
         "wasm/vendor/pdf-lib.js",
-        "wasm/vendor/*", "config.local.js", "qa/compare.html"
+        "wasm/vendor/*", "wasm/vendor/fonts/*", "config.local.js", "qa/compare.html"
       ],
       "matches": ["<all_urls>"]
     }

--- a/src/popup.html
+++ b/src/popup.html
@@ -26,7 +26,9 @@
         --text-color: #f8f9fa;
         --input-bg: #343a40;
         --input-border: #495057;
-        /* ... other dark mode colors */
+        --secondary-bg: #343a40;
+        --secondary-hover-bg: #495057;
+        --bar-bg: #495057;
       }
     }
 


### PR DESCRIPTION
## Summary
- allow wasm engine fonts to be served to extension pages
- refine dark-mode colors for quota boxes and Test button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a04db85988323b82c867e3a2485ec