### PR TITLE
Handle missing MuPDF loader in engine selection

### DIFF
--- a/src/pdfViewer.html
+++ b/src/pdfViewer.html
@@ -32,8 +32,9 @@
       </div>
     </div>
     <span class="sep"></span>
-    <select id="engineSelect" class="btn" title="Translation engine"></select>
-    <span id="engineStatus" class="muted">Engine: checking…</span>
+      <select id="engineSelect" class="btn" title="Translation engine"></select>
+      <span id="engineStatus" class="muted">Engine: checking…</span>
+      <button id="downloadEngines" class="btn" style="display:none">Setup engines</button>
     <span class="sep"></span>
     <div class="toggle-group">
       <button id="zoomOut" class="btn">-</button>

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,0 +1,62 @@
+const fs = require('fs');
+const path = require('path');
+
+function loadEngine() {
+  const code = fs.readFileSync(path.join(__dirname, '../src/wasm/engine.js'), 'utf8');
+  const transformed = code
+    .replace(/export\s+/g, '')
+    .replace(/import\.meta/g, '({url: ""})');
+  const module = { exports: {} };
+  const fn = new Function('require', 'module', 'exports', transformed + '\nreturn module.exports;');
+  return fn(require, module, module.exports);
+}
+
+describe('chooseEngine', () => {
+  const origFetch = global.fetch;
+  afterEach(() => {
+    global.fetch = origFetch;
+  });
+
+  it('falls back when mupdf loader is missing', async () => {
+    const { chooseEngine } = loadEngine();
+    const ok = new Set([
+      'base/mupdf.engine.js',
+      'base/mupdf.wasm',
+      'base/pdfium.engine.js',
+      'base/pdfium.js',
+      'base/pdfium.wasm',
+    ]);
+    global.fetch = jest.fn((url) => {
+      if (ok.has(url)) return Promise.resolve({ ok: true });
+      return Promise.reject(new Error('missing'));
+    });
+    const { choice, mupdfOk, pdfiumOk } = await chooseEngine('base/', 'auto');
+    expect(mupdfOk).toBe(false);
+    expect(pdfiumOk).toBe(true);
+    expect(choice).toBe('pdfium');
+  });
+
+  it('loads engines after assets downloaded', async () => {
+    const { chooseEngine, WASM_ASSETS, downloadWasmAssets } = loadEngine();
+    const os = require('os');
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'wasm-'));
+    await downloadWasmAssets(tmp, (url, dest) => {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, '');
+    });
+    fs.writeFileSync(path.join(tmp, 'pdfium.engine.js'), '');
+    global.fetch = jest.fn(url => {
+      const rel = url.replace('base/', '');
+      const p = path.join(tmp, rel);
+      if (fs.existsSync(p)) return Promise.resolve({ ok: true });
+      return Promise.reject(new Error('missing'));
+    });
+    const { choice, mupdfOk, pdfiumOk } = await chooseEngine('base/', 'auto');
+    for (const a of WASM_ASSETS) {
+      expect(fs.existsSync(path.join(tmp, a.path))).toBe(true);
+    }
+    expect(mupdfOk).toBe(true);
+    expect(pdfiumOk).toBe(true);
+    expect(choice).toBe('mupdf');
+  });
+});


### PR DESCRIPTION
## Summary
- list required WASM assets and helper to download them
- display available PDF engines and provide setup button to fetch missing assets
- cover engine setup flow with unit test ensuring engines function after download

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0a56cf908323a5087afce99513f9