### PR TITLE
fix throttle and batch translation

### DIFF
--- a/src/popup.html
+++ b/src/popup.html
@@ -77,6 +77,13 @@
     #version { font-size: 0.75rem; text-align: center; opacity: 0.7; }
     .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 0.75rem; }
     summary { cursor: pointer; font-weight: 600; }
+    #usageDetails { padding: 0.25rem 0.5rem; background: var(--secondary-bg); border-radius: 8px; }
+    #usageDetails summary { list-style: none; }
+    #usageDetails[open] .usage-section { animation: fadeIn 0.3s ease-in; }
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(-4px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
   </style>
 </head>
 <body>
@@ -111,21 +118,23 @@
         </div>
       </div>
 
-      <div class="usage-section">
-        <div class="usage-item">
-          <span>Requests: <span id="reqCount">0/0</span></span>
-          <div class="bar"><div id="reqBar"></div></div>
+      <details open id="usageDetails">
+        <summary>Usage</summary>
+        <div class="usage-section">
+          <div class="usage-item">
+            <span>Requests: <span id="reqCount">0/0</span></span>
+            <div class="bar"><div id="reqBar"></div></div>
+          </div>
+          <div class="usage-item">
+            <span>Tokens: <span id="tokenCount">0/0</span></span>
+            <div class="bar"><div id="tokenBar"></div></div>
+          </div>
+          <div class="usage-item">Total Requests: <span id="totalReq">0</span></div>
+          <div class="usage-item">Total Tokens: <span id="totalTok">0</span></div>
+          <div class="usage-item">Queue: <span id="queueLen">0</span></div>
         </div>
-        <div class="usage-item">
-          <span>Tokens: <span id="tokenCount">0/0</span></span>
-          <div class="bar"><div id="tokenBar"></div></div>
-        </div>
-        <div class="usage-item">Total Requests: <span id="totalReq">0</span></div>
-        <div class="usage-item">Total Tokens: <span id="totalTok">0</span></div>
-      <div class="usage-item">Queue: <span id="queueLen">0</span></div>
-      </div>
-
-      <div id="costSection"></div>
+        <div id="costSection"></div>
+      </details>
 
       <div class="grid-2">
         <div>
@@ -175,6 +184,7 @@
             <option value="">— Choose a provider —</option>
             <option value="dashscope">DashScope (Qwen)</option>
             <option value="openai">OpenAI</option>
+            <option value="openrouter">OpenRouter</option>
             <option value="deepl">DeepL</option>
           </select>
 
@@ -217,6 +227,7 @@
   <script src="throttle.js"></script>
   <script src="lib/providers.js"></script>
   <script src="providers/openai.js"></script>
+  <script src="providers/openrouter.js"></script>
   <script src="providers/deepl.js"></script>
   <script src="providers/dashscope.js"></script>
   <script src="lib/messaging.js"></script>

--- a/src/popup.js
+++ b/src/popup.js
@@ -256,6 +256,7 @@ window.qwenLoadConfig().then(cfg => {
       const presets = {
         dashscope: { endpoint: 'https://dashscope-intl.aliyuncs.com/api/v1', model: 'qwen-mt-turbo' },
         openai:    { endpoint: 'https://api.openai.com/v1',                   model: 'gpt-4o-mini' },
+        openrouter:{ endpoint: 'https://openrouter.ai/api/v1',               model: 'gpt-4o-mini' },
         deepl:     { endpoint: 'https://api.deepl.com/v2',                    model: 'deepl' }
       };
       const p = presets[v];
@@ -274,6 +275,7 @@ window.qwenLoadConfig().then(cfg => {
       const v = (endpointInput.value || '').toLowerCase();
       let inferred = '';
       if (v.includes('openai')) inferred = 'openai';
+      else if (v.includes('openrouter')) inferred = 'openrouter';
       else if (v.includes('deepl')) inferred = 'deepl';
       else if (v.includes('dashscope')) inferred = 'dashscope';
       if (inferred && providerPreset) {

--- a/src/providers/openrouter.js
+++ b/src/providers/openrouter.js
@@ -1,0 +1,92 @@
+(function (root, factory) {
+  const mod = factory(root);
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  else root.qwenProviderOpenRouter = mod;
+}(typeof self !== 'undefined' ? self : this, function (root) {
+  const logger = (root.qwenLogger && root.qwenLogger.create) ? root.qwenLogger.create('provider:openrouter') : console;
+  const fetchFn = (typeof fetch !== 'undefined') ? fetch : (root.fetch || null);
+  function withSlash(u) { return /\/$/.test(u) ? u : (u + '/'); }
+
+  async function translate({ endpoint, apiKey, model, text, source, target, signal, debug, onData, stream = true, referer, title }) {
+    if (!fetchFn) throw new Error('fetch not available');
+    const base = withSlash(endpoint || 'https://openrouter.ai/api/v1');
+    const url = base + 'chat/completions';
+    const sys = `You are a professional translator. Translate the user message from ${source} to ${target}. Output only the translation, no explanations.`;
+    const body = { model, messages: [{ role: 'system', content: sys }, { role: 'user', content: text }], stream: !!stream };
+    const headers = { 'Content-Type': 'application/json' };
+    const key = (apiKey || '').trim();
+    if (key) headers.Authorization = /^bearer\s/i.test(key) ? key : `Bearer ${key}`;
+    if (referer) headers['HTTP-Referer'] = referer;
+    if (title) headers['X-Title'] = title;
+
+    if (debug) {
+      logger.debug('sending translation request to', url);
+      logger.debug('request params', { model, source, target });
+    }
+
+    const resp = await fetchFn(url, { method: 'POST', headers, body: JSON.stringify(body), signal });
+    if (!resp.ok) {
+      let msg = resp.statusText;
+      try { const err = await resp.json(); msg = err.error?.message || msg; } catch {}
+      const error = new Error(`HTTP ${resp.status}: ${msg}`);
+      error.status = resp.status;
+      if (resp.status >= 500 || resp.status === 429) {
+        error.retryable = true;
+        const ra = resp.headers.get('retry-after');
+        if (ra) {
+          const ms = parseInt(ra, 10) * 1000;
+          if (ms > 0) error.retryAfter = ms;
+        }
+        if (resp.status === 429 && !error.retryAfter) error.retryAfter = 60000;
+      }
+      throw error;
+    }
+
+    if (!stream || !resp.body || typeof resp.body.getReader !== 'function') {
+      const data = await resp.json();
+      const out = data.choices?.[0]?.message?.content;
+      if (!out) throw new Error('Invalid API response');
+      return { text: out };
+    }
+
+    // streaming SSE
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+    let result = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed.startsWith('data:')) continue;
+        const data = trimmed.slice(5).trim();
+        if (debug) logger.debug('raw line', data);
+        if (data === '[DONE]') {
+          try { reader.cancel(); } catch {}
+          break;
+        }
+        try {
+          const obj = JSON.parse(data);
+          const chunk = obj.choices?.[0]?.delta?.content || '';
+          if (chunk) {
+            result += chunk;
+            if (onData) onData(chunk);
+            if (debug) logger.debug('chunk received', chunk);
+          }
+        } catch {}
+      }
+    }
+    return { text: result };
+  }
+
+  // Register into provider registry if available
+  try {
+    const reg = root.qwenProviders || (typeof require !== 'undefined' ? require('../lib/providers') : null);
+    if (reg && reg.register) reg.register('openrouter', { translate });
+  } catch {}
+  return { translate };
+}));

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -16,6 +16,7 @@
   let totalRequests = 0
   let totalTokens = 0
   let processing = false
+  let cooldown = false
   let interval = setInterval(() => {
     availableRequests = config.requestLimit
     availableTokens = config.tokenLimit
@@ -53,35 +54,47 @@ function prune(now = Date.now()) {
 }
 
   function processQueue() {
-    if (processing) return;
+    if (processing || cooldown) return;
+    if (!queue.length) return;
+    if (availableRequests <= 0 || availableTokens < queue[0].tokens) return;
     processing = true;
     const interval = Math.ceil(config.windowMs / config.requestLimit);
-    const step = () => {
-      if (!queue.length || availableRequests <= 0 || availableTokens < queue[0].tokens) {
-        processing = false;
-        return;
-      }
-      const item = queue.shift();
-      availableRequests--;
-      availableTokens -= item.tokens;
-      recordUsage(item.tokens);
-      item.fn().then(item.resolve, item.reject);
-      if (queue.length) {
-        setTimeout(step, interval);
-      } else {
-        processing = false;
-      }
-    };
-    step();
+    const item = queue.shift();
+    availableRequests--;
+    availableTokens -= item.tokens;
+    recordUsage(item.tokens);
+    item.fn().then(item.resolve, item.reject);
+    processing = false;
+    cooldown = true;
+    setTimeout(() => {
+      cooldown = false;
+      processQueue();
+    }, interval);
   }
 
-  function runWithRateLimit(fn, text) {
-  const tokens = typeof text === 'number' ? text : approxTokens(text || '');
-  return new Promise((resolve, reject) => {
-    queue.push({ fn, tokens, resolve, reject });
-    processQueue();
-  });
-}
+  function runWithRateLimit(fn, text, opts = {}) {
+    const tokens = typeof text === 'number' ? text : approxTokens(text || '');
+    return new Promise((resolve, reject) => {
+      if (
+        opts.immediate &&
+        !cooldown &&
+        availableRequests > 0 &&
+        availableTokens >= tokens
+      ) {
+        availableRequests--;
+        availableTokens -= tokens;
+        recordUsage(tokens);
+        try {
+          Promise.resolve(fn()).then(resolve, reject);
+        } catch (e) {
+          reject(e);
+        }
+        return;
+      }
+      queue.push({ fn, tokens, resolve, reject });
+      processQueue();
+    });
+  }
 
 function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -93,7 +106,7 @@ async function runWithRetry(fn, text, attempts = 6, debug = false) {
   for (let i = 0; i < attempts; i++) {
     try {
       if (debug) tLogger.debug('attempt', i + 1);
-      return await runWithRateLimit(fn, tokens);
+      return await runWithRateLimit(fn, tokens, { immediate: true });
     } catch (err) {
       if (!err.retryable || i === attempts - 1) throw err;
       const base = err.retryAfter || wait;


### PR DESCRIPTION
## Summary
- refine provider registry loading to avoid overriding tests
- add cooldown-aware rate limiter with immediate bypass
- skip chrome proxy in batch translation to prevent hanging when `chrome.runtime` is mocked
- add OpenRouter provider option and collapsible usage stats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ed79cc8688323becb094870f0ae3a