### PR TITLE
Use provider quota for usage bars

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ const defaultCfg = {
   targetLanguage: 'en',
   autoTranslate: false,
   requestLimit: 60,
-  tokenLimit: 100000,
+  tokenLimit: 31980,
   tokenBudget: 0,
   memCacheMax: 5000,
   sensitivity: 0.3,
@@ -20,8 +20,8 @@ const defaultCfg = {
 };
 
 const modelTokenLimits = {
-  'qwen-mt-turbo': 100000,
-  'qwen-mt-plus': 100000,
+  'qwen-mt-turbo': 31980,
+  'qwen-mt-plus': 23797,
   'gpt-4o-mini': 128000,
 };
 


### PR DESCRIPTION
## Summary
- set qwen-mt-turbo default token limit to 31 980 and qwen-mt-plus to 23 797 tokens/min based on official quotas
- drive popup usage bars from provider quota and add tooltip with refresh time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689f95cd585883238ad312a14cbae68f