### PR TITLE
Poll quota via background message in popup

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -666,29 +666,35 @@ function renderProviderUsage(cfg, stats = {}) {
   });
 }
 
-async function refreshQuota() {
-  const prov = (window.qwenProviders && window.qwenProviders.getProvider &&
-    window.qwenProviders.getProvider('qwen'));
-  if (!prov || typeof prov.getQuota !== 'function') return;
-  const cfg = window.qwenConfig || {};
-  for (const model of ['qwen-mt-turbo', 'qwen-mt-plus']) {
-    try {
-      const res = await prov.getQuota({
-        endpoint: cfg.apiEndpoint,
-        apiKey: cfg.apiKey,
-        model,
-        debug: cfg.debug,
-      });
-      if (!res || !res.remaining) continue;
+function refreshQuota() {
+  ['qwen-mt-turbo', 'qwen-mt-plus'].forEach(model => {
+    chrome.runtime.sendMessage({ action: 'quota', model }, res => {
+      if (chrome.runtime.lastError || !res || !res.remaining) return;
       const rem = res.remaining || {};
       const used = res.used || {};
       const total = (used.requests || 0) + (rem.requests || 0);
       const bar = model === 'qwen-mt-turbo' ? turboReqBar : plusReqBar;
       setBar(bar, total ? (rem.requests || 0) / total : 0);
       bar.textContent = `${rem.requests || 0}r ${rem.tokens || 0}t`;
-    } catch {}
-  }
+    });
+  });
 }
+
+let quotaInterval;
+function scheduleQuota() {
+  if (quotaInterval) clearInterval(quotaInterval);
+  refreshQuota();
+  quotaInterval = setInterval(refreshQuota, 30000);
+}
+
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'visible') {
+    scheduleQuota();
+  } else if (quotaInterval) {
+    clearInterval(quotaInterval);
+    quotaInterval = null;
+  }
+});
 
 function refreshUsage() {
   chrome.runtime.sendMessage({ action: 'usage' }, res => {
@@ -722,8 +728,7 @@ function refreshUsage() {
   });
 }
 
-setInterval(refreshQuota, 30000);
-refreshQuota();
+scheduleQuota();
 setInterval(refreshUsage, 1000);
 refreshUsage();
 


### PR DESCRIPTION
## Summary
- Poll quota via background messaging for `qwen-mt-turbo` and `qwen-mt-plus`
- Update popup quota bars and refresh them every 30s while visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ffe670098832382320f3aa54084ae