### PR TITLE
feat: surface cache and TM metrics in popup

### DIFF
--- a/src/popup.js
+++ b/src/popup.js
@@ -42,7 +42,9 @@
         ]).then(([metrics, provCfg, autoCfg]) => {
           const provider = (provCfg.providerOrder && provCfg.providerOrder[0]) || provCfg.provider || 'default';
           const usage = metrics && metrics.usage ? metrics.usage : {};
-          sendResponse({ provider, usage, auto: autoCfg.autoTranslate });
+          const cache = metrics && metrics.cache ? metrics.cache : {};
+          const tm = metrics && metrics.tm ? metrics.tm : {};
+          sendResponse({ provider, usage, cache, tm, auto: autoCfg.autoTranslate });
         });
         return true;
       case 'home:get-usage':

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -48,6 +48,7 @@
   <progress id="reqBar" value="0" max="0"></progress>
   <progress id="tokBar" value="0" max="0"></progress>
   <div id="limits" class="stats"></div>
+  <div id="cacheStatus" class="stats"></div>
   <button id="toDiagnostics" class="secondary">Diagnostics</button>
   <script src="../languages.js"></script>
   <script src="../usageColor.js"></script>

--- a/src/popup/home.js
+++ b/src/popup/home.js
@@ -4,6 +4,7 @@
   const providerName = document.getElementById('providerName');
   const usageEl = document.getElementById('usage');
   const limitsEl = document.getElementById('limits');
+  const cacheEl = document.getElementById('cacheStatus');
   const reqBar = document.getElementById('reqBar');
   const tokBar = document.getElementById('tokBar');
   const srcSel = document.getElementById('srcLang');
@@ -59,6 +60,9 @@
     const u = res.usage || {};
     usageEl.textContent = `Requests: ${u.requests || 0}/${u.requestLimit || 0} Tokens: ${u.tokens || 0}/${u.tokenLimit || 0}`;
     if (limitsEl) limitsEl.textContent = `Queue: ${u.queue || 0}`;
+    const c = res.cache || {};
+    const t = res.tm || {};
+    if (cacheEl) cacheEl.textContent = `Cache: ${c.size || 0}/${c.max || 0} TM: ${t.hits || 0}/${t.misses || 0}`;
     if (reqBar) {
       reqBar.max = u.requestLimit || 0;
       reqBar.value = u.requests || 0;

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -60,11 +60,14 @@ describe('popup shell routing', () => {
 
   test('initializes home view via home:init', async () => {
     chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
-      if (msg.action === 'metrics') cb({ usage: { requests: 1, tokens: 2 } });
+      if (msg.action === 'metrics') cb({ usage: { requests: 1, tokens: 2 }, cache: {}, tm: {} });
     });
     require('../src/popup.js');
     await new Promise(resolve => {
-    const ret = listener({ action: 'home:init' }, {}, res => { expect(res).toEqual({ provider: 'qwen', usage: { requests: 1, tokens: 2 }, auto: false }); resolve(); });
+    const ret = listener({ action: 'home:init' }, {}, res => {
+      expect(res).toEqual({ provider: 'qwen', usage: { requests: 1, tokens: 2 }, cache: {}, tm: {}, auto: false });
+      resolve();
+    });
       expect(ret).toBe(true);
     });
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'metrics' }, expect.any(Function));

--- a/test/popupCache.test.js
+++ b/test/popupCache.test.js
@@ -12,13 +12,14 @@ describe('home usage updates', () => {
       <progress id="reqBar" value="0" max="0"></progress>
       <progress id="tokBar" value="0" max="0"></progress>
       <div id="limits"></div>
+      <div id="cacheStatus"></div>
       <button id="toDiagnostics"></button>
     `;
     listener = undefined;
     global.chrome = {
       runtime: {
         sendMessage: jest.fn((msg, cb) => {
-          if (msg.action === 'home:init') cb({ provider: 'p', usage: { requests: 1, tokens: 2, requestLimit: 10, tokenLimit: 20, queue: 0 }, auto: false });
+          if (msg.action === 'home:init') cb({ provider: 'p', usage: { requests: 1, tokens: 2, requestLimit: 10, tokenLimit: 20, queue: 0 }, cache: {}, tm: {}, auto: false });
         }),
         onMessage: { addListener: fn => { listener = fn; } },
       },

--- a/test/popupCost.test.js
+++ b/test/popupCost.test.js
@@ -11,6 +11,7 @@ describe('home view display', () => {
       <progress id="reqBar" value="0" max="0"></progress>
       <progress id="tokBar" value="0" max="0"></progress>
       <div id="limits"></div>
+      <div id="cacheStatus"></div>
       <button id="toDiagnostics"></button>
     `;
     global.chrome = {
@@ -31,7 +32,13 @@ describe('home view display', () => {
 
   test('initializes and handles actions', () => {
     chrome.runtime.sendMessage.mockImplementation((msg, cb) => {
-      if (msg.action === 'home:init') cb({ provider: 'qwen', usage: { requests: 5, tokens: 10, requestLimit: 100, tokenLimit: 200, queue: 0 }, auto: false });
+      if (msg.action === 'home:init') cb({
+        provider: 'qwen',
+        usage: { requests: 5, tokens: 10, requestLimit: 100, tokenLimit: 200, queue: 0 },
+        cache: { size: 1, max: 2 },
+        tm: { hits: 3, misses: 4 },
+        auto: false,
+      });
     });
     require('../src/popup/home.js');
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:init' }, expect.any(Function));
@@ -39,6 +46,7 @@ describe('home view display', () => {
     expect(document.getElementById('usage').textContent).toBe('Requests: 5/100 Tokens: 10/200');
     expect(document.getElementById('reqBar').value).toBe(5);
     expect(document.getElementById('reqBar').max).toBe(100);
+    expect(document.getElementById('cacheStatus').textContent).toBe('Cache: 1/2 TM: 3/4');
 
     document.getElementById('quickTranslate').click();
     expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'home:quick-translate' });


### PR DESCRIPTION
## Summary
- show cache and TM stats in popup home view
- include cache and TM metrics in home:init message
- test coverage for cache and TM metrics display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2035da4d08323a900e417c69fc6a3