### PR TITLE
fix: delay popup resize until iframe load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.4",
+  "version": "1.28.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.28.4",
+      "version": "1.28.6",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.5",
+  "version": "1.28.6",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup.html
+++ b/src/popup.html
@@ -11,6 +11,7 @@
       font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
       color: var(--qwen-text, #f5f5f7);
       margin: 0;
+      width: 300px; /* default width until iframe resizes */
     }
     #nav {
       display: flex;

--- a/src/popup.js
+++ b/src/popup.js
@@ -34,12 +34,14 @@
       ro.observe(doc.documentElement);
     } catch {}
   }
-
   frame?.addEventListener('load', () => {
     resize();
     observeResize();
   });
-  resize();
+  if (frame?.contentDocument && frame.contentDocument.readyState === 'complete') {
+    resize();
+    observeResize();
+  }
 
   chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     if (!msg || !msg.action) return;


### PR DESCRIPTION
## Summary
- ensure popup resize runs after iframe load and only when contentDocument is ready
- set a default popup width until resizing occurs
- bump version to 1.28.6 / 1.26.3

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a241df8bd8832388a6d7e48b83ec7a