### PR TITLE
Guard scripts against repeated execution

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,12 @@
+(function () {
+if (typeof window !== 'undefined') {
+  if (window.__qwenConfigLoaded) {
+    if (typeof module !== 'undefined') module.exports = window.__qwenConfigModule;
+    return;
+  }
+  window.__qwenConfigLoaded = true;
+}
+
 const defaultCfg = {
   apiKey: '',
   detectApiKey: '',
@@ -137,12 +146,15 @@ function qwenSaveConfig(cfg) {
   return Promise.resolve(); // Otherwise, do nothing
 }
 
+if (typeof module !== 'undefined') {
+  module.exports = { qwenLoadConfig, qwenSaveConfig, defaultCfg, modelTokenLimits };
+}
 if (typeof window !== 'undefined') {
   window.qwenDefaultConfig = defaultCfg;
   window.qwenLoadConfig = qwenLoadConfig;
   window.qwenSaveConfig = qwenSaveConfig;
+  window.qwenModelTokenLimits = modelTokenLimits;
+  window.__qwenConfigModule = module.exports;
 }
 
-if (typeof module !== 'undefined') {
-  module.exports = { qwenLoadConfig, qwenSaveConfig, defaultCfg, modelTokenLimits };
-}
+})();

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,6 +1,10 @@
+(function () {
+if (typeof window !== 'undefined') {
+  if (window.__qwenCSLoaded) return;
+  window.__qwenCSLoaded = true;
+}
+
 const skipInit = location.href.startsWith(chrome.runtime.getURL('pdfViewer.html'));
-if (window.__qwenCSLoaded) { /* already initialized */ }
-else window.__qwenCSLoaded = true;
 const logger = (window.qwenLogger && window.qwenLogger.create) ? window.qwenLogger.create('content') : console;
 let observers = [];
 let currentConfig;
@@ -798,3 +802,5 @@ if (typeof module !== 'undefined') {
     },
   };
 }
+
+})();

--- a/src/translator.js
+++ b/src/translator.js
@@ -1,3 +1,12 @@
+(function () {
+if (typeof window !== 'undefined') {
+  if (window.__qwenTranslatorLoaded) {
+    if (typeof module !== 'undefined') module.exports = window.__qwenTranslatorModule;
+    return;
+  }
+  window.__qwenTranslatorLoaded = true;
+}
+
 let fetchFn = typeof fetch !== 'undefined' ? fetch : undefined;
 var approxTokens;
 var createThrottle;
@@ -944,13 +953,6 @@ function qwenClearCache() {
   cache.clear();
   _persistClear();
 }
-if (typeof window !== 'undefined') {
-  window.qwenTranslate = qwenTranslate;
-  window.qwenTranslateStream = qwenTranslateStream;
-  window.qwenTranslateBatch = qwenTranslateBatch;
-  window.qwenClearCache = qwenClearCache;
-  window.qwenSetTokenBudget = _setTokenBudget;
-}
 if (typeof self !== 'undefined' && typeof window === 'undefined') {
   self.qwenTranslate = qwenTranslate;
   self.qwenTranslateStream = qwenTranslateStream;
@@ -970,9 +972,17 @@ if (typeof module !== 'undefined') {
     qwenGetCacheSize,
     _setGetUsage,
     _getTokenBudget,
-    _setTokenBudget,
-    _throttleKeys: () => Array.from(throttles.keys()),
+  _setTokenBudget,
+  _throttleKeys: () => Array.from(throttles.keys()),
   };
+}
+if (typeof window !== 'undefined') {
+  window.qwenTranslate = qwenTranslate;
+  window.qwenTranslateStream = qwenTranslateStream;
+  window.qwenTranslateBatch = qwenTranslateBatch;
+  window.qwenClearCache = qwenClearCache;
+  window.qwenSetTokenBudget = _setTokenBudget;
+  window.__qwenTranslatorModule = module.exports;
 }
 let chooseStrategy = () => 'proxy';
 try {
@@ -980,3 +990,5 @@ try {
   else if (typeof self !== 'undefined' && typeof window === 'undefined' && self.qwenFetchStrategy) chooseStrategy = self.qwenFetchStrategy.choose;
   else if (typeof require !== 'undefined') chooseStrategy = require('./lib/fetchStrategy').choose;
 } catch {}
+
+})();


### PR DESCRIPTION
## Summary
- Prevent config from reinitializing by guarding with `__qwenConfigLoaded`
- Guard translator module with `__qwenTranslatorLoaded` and re-export existing module if already loaded
- Wrap content script in single-run check `__qwenCSLoaded`

## Testing
- `npm test` *(fails: 7 failed, 47 passed, 54 total)*

------
https://chatgpt.com/codex/tasks/task_e_68a248dbb0148323a349142ab571cf74