### PR TITLE
Add theme selector and extend apple styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.7",
+  "version": "1.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.28.7",
+      "version": "1.29.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.28.7",
+  "version": "1.29.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -222,6 +222,12 @@ chrome.runtime.onMessage.addListener(msg => {
       pageRecognizer = null;
       clearStatus();
     }
+  } else if (msg.action === 'update-theme') {
+    currentConfig = currentConfig || {};
+    currentConfig.theme = msg.theme;
+    document.querySelectorAll('[data-qwen-theme="apple"]').forEach(el => {
+      el.setAttribute('data-qwen-color', msg.theme);
+    });
   }
 });
 function mark(node) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.28.7",
+  "version": "1.29.0",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup.js
+++ b/src/popup.js
@@ -24,6 +24,15 @@
     } catch {}
   }
 
+  chrome.storage?.sync?.get({ theme: 'dark' }, data => {
+    const theme = data.theme || 'dark';
+    document.documentElement.setAttribute('data-qwen-color', theme);
+    chrome.tabs?.query?.({ active: true, currentWindow: true }, tabs => {
+      const t = tabs && tabs[0];
+      if (t) chrome.tabs.sendMessage(t.id, { action: 'update-theme', theme }, handleLastError());
+    });
+  });
+
   function load(page) {
     if (frame) frame.src = `popup/${page}`;
     current = page;

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -30,6 +30,14 @@
     .lang-select select {
       flex: 1;
     }
+    .theme-select {
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+    }
+    .theme-select select {
+      flex: 1;
+    }
     .stats {
       font-size: 0.75rem;
     }
@@ -44,6 +52,13 @@
     <select id="srcLang"></select>
     <span>→</span>
     <select id="destLang"></select>
+  </div>
+  <div class="theme-select">
+    <label for="theme">Theme</label>
+    <select id="theme">
+      <option value="dark">Dark</option>
+      <option value="light">Light</option>
+    </select>
   </div>
   <label class="auto-toggle"><input type="checkbox" id="autoTranslate"> Auto-translate</label>
   <div id="provider">Provider: <span id="providerName">-</span> <span id="providerKey"></span></div>

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -44,6 +44,13 @@
   </div>
 
   <div id="generalTab" class="tab">
+    <section id="themeSection">
+      <h3>Theme</h3>
+      <select id="theme">
+        <option value="dark">Dark</option>
+        <option value="light">Light</option>
+      </select>
+    </section>
     <section id="detectionSection">
       <h3>Language Detection</h3>
       <label><input type="checkbox" id="enableDetection"> Enable automatic detection</label>

--- a/src/styles/apple.css
+++ b/src/styles/apple.css
@@ -23,6 +23,7 @@
 
 [data-qwen-theme="apple"] input[type="text"],
 [data-qwen-theme="apple"] input[type="number"],
+[data-qwen-theme="apple"] textarea,
 [data-qwen-theme="apple"] select {
   box-sizing: border-box;
   padding: 0.5rem 0.75rem;
@@ -36,6 +37,7 @@
 }
 
 [data-qwen-theme="apple"] input:focus,
+[data-qwen-theme="apple"] textarea:focus,
 [data-qwen-theme="apple"] select:focus {
   outline: none;
   border-color: var(--qwen-input-focus);
@@ -74,6 +76,42 @@
 [data-qwen-theme="apple"] button.primary:hover,
 [data-qwen-theme="apple"] a.button.primary:hover {
   background: var(--qwen-primary-hover);
+}
+
+[data-qwen-theme="apple"] button.secondary,
+[data-qwen-theme="apple"] a.button.secondary {
+  background: var(--qwen-secondary-bg);
+  color: var(--qwen-text);
+}
+
+[data-qwen-theme="apple"] button.secondary:hover,
+[data-qwen-theme="apple"] a.button.secondary:hover {
+  background: var(--qwen-secondary-hover);
+}
+
+[data-qwen-theme="apple"] button:disabled,
+[data-qwen-theme="apple"] a.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+[data-qwen-theme="apple"] progress {
+  width: 100%;
+  height: 1rem;
+  -webkit-appearance: none;
+  appearance: none;
+}
+[data-qwen-theme="apple"] progress::-webkit-progress-bar {
+  background: var(--qwen-secondary-bg);
+  border-radius: 8px;
+}
+[data-qwen-theme="apple"] progress::-webkit-progress-value {
+  background: var(--qwen-primary-bg);
+  border-radius: 8px;
+}
+[data-qwen-theme="apple"] progress::-moz-progress-bar {
+  background: var(--qwen-primary-bg);
+  border-radius: 8px;
 }
 
 
@@ -135,4 +173,14 @@
 @keyframes qwen-bubble-fade {
   from { opacity: 0; transform: scale(0.95); }
   to { opacity: 1; transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-qwen-theme="apple"] button,
+  [data-qwen-theme="apple"] a.button {
+    transition: none !important;
+  }
+  .qwen-bubble {
+    animation: none !important;
+  }
 }


### PR DESCRIPTION
## Summary
- add theme dropdown to home and settings pages
- extend apple.css to style more inputs/buttons and honor reduced motion
- load saved theme in popup and forward updates to content-script HUD

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a27a92a1dc8323bf86e89932a19dda