### PR TITLE
Add auto-translate and streaming cancel e2e tests

### DIFF
--- a/e2e/streaming-cancel.spec.js
+++ b/e2e/streaming-cancel.spec.js
@@ -1,0 +1,35 @@
+const { test, expect } = require('@playwright/test');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+
+test('aborts streaming translation mid-stream', async ({ page }) => {
+  await page.goto(pageUrl);
+  const res = await page.evaluate(() => {
+    return new Promise(async resolve => {
+      window.qwenProviders.registerProvider('stream', {
+        async translate({ text, onData, signal }) {
+          const chunks = ['Bon', 'jour'];
+          for (const chunk of chunks) {
+            if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+            await new Promise(r => setTimeout(r, 100));
+            if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+            if (onData) onData(chunk);
+          }
+          return { text: 'Bonjour' };
+        }
+      });
+      const controller = new AbortController();
+      const pieces = [];
+      window.qwenTranslateStream(
+        { provider: 'stream', text: 'hello', source: 'en', target: 'fr', stream: true, signal: controller.signal },
+        chunk => pieces.push(chunk)
+      ).then(
+        () => resolve({ error: null, chunks: pieces }),
+        e => resolve({ error: e.name, chunks: pieces })
+      );
+      setTimeout(() => controller.abort(), 150);
+    });
+  });
+  expect(res.error).toBe('AbortError');
+  expect(res.chunks).toEqual(['Bon']);
+});

--- a/e2e/translate-page.spec.js
+++ b/e2e/translate-page.spec.js
@@ -1,0 +1,40 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const pageUrl = 'http://127.0.0.1:8080/e2e/mock.html';
+const contentScript = fs.readFileSync(path.join(__dirname, '../src/contentScript.js'), 'utf8');
+
+test('auto translates page content', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.chrome = {
+      runtime: {
+        getURL: () => 'chrome-extension://abc/',
+        sendMessage: () => {},
+        onMessage: { addListener: () => {} }
+      },
+      storage: { sync: { get: (_keys, cb) => cb({}), set: () => {} } }
+    };
+    window.qwenCache = {
+      cacheReady: Promise.resolve(),
+      getCache: () => null,
+      setCache: () => {},
+      removeCache: () => {},
+      qwenClearCache: () => {},
+      qwenGetCacheSize: () => 0,
+      qwenSetCacheLimit: () => {},
+      qwenSetCacheTTL: () => {}
+    };
+    window.qwenLoadConfig = async () => ({
+      provider: 'mock',
+      sourceLanguage: 'en',
+      targetLanguage: 'fr',
+      autoTranslate: true
+    });
+  });
+  await page.goto(pageUrl);
+  await page.addScriptTag({ content: contentScript });
+  await page.waitForFunction(() => document.querySelector('p').textContent.endsWith('-fr'));
+  const txt = await page.textContent('p');
+  expect(txt).toBe('Mock page for E2E translation tests.-fr');
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "build:safari": "bash scripts/convert-safari.sh",
-    "test:e2e:web": "playwright test e2e/context-menu.spec.js e2e/dom-translate.spec.js",
+    "test:e2e:web": "playwright test e2e/context-menu.spec.js e2e/dom-translate.spec.js e2e/translate-page.spec.js e2e/streaming-cancel.spec.js",
     "test:e2e:pdf": "playwright test e2e/pdf-compare.spec.js",
     "test:e2e": "npm run test:e2e:web && npm run test:e2e:pdf",
     "e2e": "npm run test:e2e",


### PR DESCRIPTION
## Summary
- cover auto-translate in new translate-page e2e spec
- add streaming cancel e2e test using AbortController
- run new specs via npm run test:e2e

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_68a2801112308323b5759ccbaace6320