### PR TITLE
Add detection sensitivity setting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/lib/detect.js
+++ b/src/lib/detect.js
@@ -6,7 +6,7 @@
   function detectLocal(text, { sensitivity = 0, minLength = 0 } = {}) {
     const s = String(text || '');
     const total = s.replace(/\s+/g, '').length;
-    if (total < minLength) return { lang: 'en', confidence: 0 };
+    if (total < minLength) return { lang: undefined, confidence: 0 };
     const counts = {
       ja: (s.match(/[\u3040-\u30ff\u4e00-\u9fff]/g) || []).length,
       ko: (s.match(/[\uac00-\ud7af]/g) || []).length,
@@ -17,8 +17,9 @@
     };
     let best = 'en', max = 0;
     for (const [k, v] of Object.entries(counts)) { if (v > max) { max = v; best = k; } }
+    if (max === 0) return { lang: undefined, confidence: 0 };
     const confidence = total ? Math.min(1, max / total) : 0;
-    if (confidence < sensitivity) return { lang: 'en', confidence };
+    if (confidence < sensitivity) return { lang: undefined, confidence };
     return { lang: best, confidence };
   }
   return { detectLocal };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -54,7 +54,8 @@
     <section id="detectionSection">
       <h3>Language Detection</h3>
       <label><input type="checkbox" id="enableDetection"> Enable automatic detection</label>
-      <p class="note">Automatically detect the source language before translating.</p>
+      <label>Sensitivity <input type="number" id="sensitivity" min="0" max="1" step="0.1"></label>
+      <p class="note">Automatically detect the source language before translating. Detection is ignored when confidence is below the sensitivity.</p>
     </section>
     <section id="glossarySection">
       <h3>Glossary</h3>

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -7,6 +7,7 @@
     cacheEnabled: false,
     localProviders: [],
     selectionPopup: false,
+    sensitivity: 0.3,
   };
 
   function handleLastError(cb) {
@@ -64,6 +65,15 @@
   detectBox.addEventListener('change', () => {
     chrome?.storage?.sync?.set({ enableDetection: detectBox.checked });
   });
+
+  const sensitivityField = document.getElementById('sensitivity');
+  if (sensitivityField) {
+    sensitivityField.value = typeof store.sensitivity === 'number' ? store.sensitivity : 0;
+    sensitivityField.addEventListener('input', () => {
+      const val = Number(sensitivityField.value);
+      chrome?.storage?.sync?.set({ sensitivity: val });
+    });
+  }
 
   const selectionBox = document.getElementById('selectionPopup');
   if (selectionBox) {

--- a/test/detect.test.js
+++ b/test/detect.test.js
@@ -1,0 +1,25 @@
+const { detectLocal } = require('../src/lib/detect.js');
+
+describe('detectLocal short strings', () => {
+  test('detects single Japanese character', () => {
+    const r = detectLocal('あ');
+    expect(r.lang).toBe('ja');
+  });
+
+  test('returns undefined when text shorter than minLength', () => {
+    const r = detectLocal('あ', { minLength: 2 });
+    expect(r.lang).toBeUndefined();
+    expect(r.confidence).toBe(0);
+  });
+
+  test('returns undefined when confidence below sensitivity', () => {
+    const r = detectLocal('h?', { sensitivity: 0.6 });
+    expect(r.lang).toBeUndefined();
+  });
+
+  test('returns undefined when no signal characters present', () => {
+    const r = detectLocal('!!!');
+    expect(r.lang).toBeUndefined();
+    expect(r.confidence).toBe(0);
+  });
+});

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.25.0" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.30.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- Allow local detection to ignore low-confidence results
- Let users configure detection sensitivity in settings
- Test detection on short inputs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a286a5fd308323921e3bdd80c1884a