### PR TITLE
feat: expose cache/TM usage metrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.29.0",
+      "version": "1.30.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -543,6 +543,12 @@ async function processQueue() {
   stats.wordsPerSecond = stats.words / (stats.elapsedMs / 1000 || 1);
   stats.wordsPerRequest = stats.words / (stats.requests || 1);
   stats.tokensPerRequest = stats.tokens / (stats.requests || 1);
+  stats.cache = {
+    size: (window.qwenGetCacheSize && window.qwenGetCacheSize()) || 0,
+    max: (window.qwenConfig && window.qwenConfig.memCacheMax) || 0,
+    ...(window.qwenGetCacheStats ? window.qwenGetCacheStats() : {}),
+  };
+  stats.tm = window.qwenTM && window.qwenTM.stats ? window.qwenTM.stats() : {};
   chrome.runtime.sendMessage({ action: 'translation-status', status: { active: false, summary: stats } }, handleLastError());
   processing = false;
   clearStatus();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.29.0",
+  "version": "1.30.0",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/throttle.js
+++ b/src/throttle.js
@@ -63,11 +63,13 @@
       processQueue();
     }
 
-    function recordUsage(tokens) {
+    function recordUsage(tokens, requests = 1) {
       const now = Date.now();
-      requestTimes.push(now);
+      for (let i = 0; i < requests; i++) {
+        requestTimes.push(now);
+      }
       tokenTimes.push({ time: now, tokens });
-      totalRequests++;
+      totalRequests += requests;
       totalTokens += tokens;
       prune(now);
     }
@@ -161,7 +163,7 @@
       cooldown = false;
     }
 
-    return { runWithRateLimit, runWithRetry, configure, approxTokens, getUsage, reset, splitSentences, predictiveBatch };
+    return { runWithRateLimit, runWithRetry, configure, approxTokens, getUsage, reset, splitSentences, predictiveBatch, recordUsage };
   }
 
   const globalThrottle = createThrottle();


### PR DESCRIPTION
## Summary
- track requests and tokens globally and expose recordUsage in throttle
- send cache and TM statistics with page translation status
- surface cache/TM hits in metrics endpoint and bump version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28821c8748323a1249e5bd8713002