### PR TITLE
feat: surface TM and cache metrics in settings

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -638,6 +638,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     });
     return true;
   }
+  if (msg.action === 'tm-cache-metrics') {
+    const tmMetrics = (self.qwenTM && self.qwenTM.stats) ? self.qwenTM.stats() : {};
+    const cacheStats = self.qwenGetCacheStats ? self.qwenGetCacheStats() : {};
+    sendResponse({ tmMetrics, cacheStats });
+    return true;
+  }
   if (msg.action === 'quota') {
     const model = msg.model;
     const cfg = self.qwenConfig || {};

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -92,6 +92,14 @@
       <h3>Usage</h3>
       <pre id="usageStats">-</pre>
     </section>
+    <section id="tmDetails">
+      <h3>TM Metrics</h3>
+      <pre id="tmMetrics">-</pre>
+    </section>
+    <section id="cacheDetails">
+      <h3>Cache Stats</h3>
+      <pre id="cacheStats">-</pre>
+    </section>
   </div>
 
   <div id="addProviderOverlay">

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -279,5 +279,13 @@
     const usage = m && m.usage ? m.usage : {};
     usageEl.textContent = JSON.stringify(usage, null, 2);
   }));
+  const tmEl = document.getElementById('tmMetrics');
+  const cacheEl = document.getElementById('cacheStats');
+  chrome?.runtime?.sendMessage({ action: 'tm-cache-metrics' }, handleLastError(m => {
+    const tmMetrics = m && m.tmMetrics ? m.tmMetrics : {};
+    const cacheStats = m && m.cacheStats ? m.cacheStats : {};
+    tmEl.textContent = JSON.stringify(tmMetrics, null, 2);
+    cacheEl.textContent = JSON.stringify(cacheStats, null, 2);
+  }));
 })();
 

--- a/test/background.tmCacheMetrics.test.js
+++ b/test/background.tmCacheMetrics.test.js
@@ -1,0 +1,24 @@
+describe('background tm/cache metrics endpoint', () => {
+  test('returns tm metrics and cache stats', async () => {
+    jest.resetModules();
+    const syncGet = jest.fn((defaults, cb) => cb(defaults));
+    global.chrome = {
+      action: { setBadgeText: jest.fn(), setBadgeBackgroundColor: jest.fn(), setIcon: jest.fn() },
+      runtime: { onInstalled: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() }, onConnect: { addListener: jest.fn() } },
+      contextMenus: { create: jest.fn(), removeAll: jest.fn(cb => cb && cb()), onClicked: { addListener: jest.fn() } },
+      tabs: { onUpdated: { addListener: jest.fn() } },
+      storage: { sync: { get: syncGet }, local: { get: jest.fn(), set: jest.fn() } },
+    };
+    global.importScripts = () => {};
+    global.setInterval = () => {};
+    global.qwenTM = { stats: () => ({ hits: 1, misses: 0 }), enableSync: jest.fn() };
+    global.qwenGetCacheStats = () => ({ hits: 2, misses: 0 });
+    global.qwenThrottle = { configure: jest.fn(), getUsage: () => ({ requests: 0, requestLimit: 1, tokens: 0, tokenLimit: 1, totalRequests:0, totalTokens:0 }) };
+    require('../src/background.js');
+    const listener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const res = await new Promise(resolve => listener({ action: 'tm-cache-metrics' }, {}, resolve));
+    expect(res.tmMetrics.hits).toBe(1);
+    expect(res.cacheStats.hits).toBe(2);
+  });
+});
+

--- a/test/settings.diagnostics.test.js
+++ b/test/settings.diagnostics.test.js
@@ -1,0 +1,50 @@
+// @jest-environment jsdom
+
+function flush() { return new Promise(res => setTimeout(res, 0)); }
+
+describe('settings diagnostics metrics', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = `
+      <div class="tabs"><button data-tab="general"></button></div>
+      <div id="generalTab">
+        <section id="detectionSection"><input type="checkbox" id="enableDetection"></section>
+        <section id="glossarySection"><textarea id="glossary"></textarea></section>
+      </div>
+      <div id="providersTab" class="tab">
+        <section id="providerSection">
+          <div id="providerList"></div>
+          <button id="addLocalProvider"></button>
+          <div id="localProviderWizard"><select id="localProviderType"></select><div id="ollamaForm"></div><div id="macosForm"></div><button id="saveLocalProvider"></button></div>
+        </section>
+      </div>
+      <div id="advancedTab">
+        <section id="limitSection"><input id="requestLimit"><input id="tokenLimit"></section>
+        <section id="cacheSection"><input type="checkbox" id="cacheEnabled"><button id="clearCache"></button></section>
+      </div>
+      <div id="diagnosticsTab">
+        <section id="statsDetails"><pre id="usageStats"></pre></section>
+        <section id="tmDetails"><pre id="tmMetrics"></pre></section>
+        <section id="cacheDetails"><pre id="cacheStats"></pre></section>
+      </div>
+    `;
+    global.chrome = {
+      storage: { sync: { get: jest.fn((defs, cb) => cb(defs)), set: jest.fn() } },
+      runtime: { sendMessage: jest.fn((msg, cb) => {
+        if (msg.action === 'metrics') cb({ usage: {} });
+        else if (msg.action === 'tm-cache-metrics') cb({ tmMetrics: { hits: 1 }, cacheStats: { hits: 2 } });
+        else cb && cb({});
+      }) },
+    };
+    window.qwenProviders = { ensureProviders: jest.fn(), listProviders: jest.fn(() => []) };
+    window.qwenProviderConfig = { loadProviderConfig: jest.fn(() => Promise.resolve({ providers: {}, providerOrder: [] })), saveProviderConfig: jest.fn(() => Promise.resolve()) };
+  });
+
+  test('displays tm and cache metrics', async () => {
+    require('../src/popup/settings.js');
+    await flush();
+    expect(document.getElementById('tmMetrics').textContent).toContain('hits');
+    expect(document.getElementById('cacheStats').textContent).toContain('hits');
+  });
+});
+


### PR DESCRIPTION
## Summary
- expose `tm-cache-metrics` route returning translation memory metrics and cache stats
- show TM and cache metrics in the settings Diagnostics tab
- add tests for background endpoint and settings display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a28884b3a883239f51024eac47bddc