### PR TITLE
feat: duplicate provider configurations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@
 - UX and theming
 - Apple HUD (`styles/apple.css`) for in-page status and popup; in-app Getting Started guide; tooltips across fields.
   - Provider presets (DashScope/OpenAI/DeepL/OpenRouter); provider-specific endpoints/keys/models; version/date shown in popup.
+  - Provider configs can be duplicated in settings to quickly clone setups for additional models.
   - Glossary and tone presets editable in popup; translator applies substitutions and formal/casual/technical tone options.
   - Logging via `qwenLogger` with levels and collectors; popup debug output uses the logger.
   - Fetch strategy is centralized in `lib/fetchStrategy.js`; override with `qwenFetchStrategy.setChooser(fn)` for custom proxy/direct routing.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -150,6 +150,22 @@
       providerConfig.providerOrder = Array.from(providerList.children).map(el => el.dataset.provider);
       window.qwenProviderConfig.saveProviderConfig(providerConfig);
     }
+    function duplicateProvider(name) {
+      const orig = providers[name];
+      if (!orig) return;
+      let newName = `${name}-copy`;
+      let i = 1;
+      while (providers[newName]) newName = `${name}-copy${i++}`;
+      providers[newName] = { ...orig };
+      const impl = window.qwenProviders?.getProvider?.(name);
+      if (impl) window.qwenProviders?.registerProvider?.(newName, impl);
+      if (!Array.isArray(providerConfig.providerOrder)) providerConfig.providerOrder = [];
+      const idx = providerConfig.providerOrder.indexOf(name);
+      if (idx >= 0) providerConfig.providerOrder.splice(idx + 1, 0, newName);
+      else providerConfig.providerOrder.push(newName);
+      window.qwenProviderConfig.saveProviderConfig(providerConfig);
+      openEditor(newName);
+    }
     order.forEach(name => {
       const meta = available.find(p => p.name === name) || { name, label: name };
       if (!providers[name]) providers[name] = {};
@@ -176,6 +192,11 @@
       edit.textContent = 'Edit';
       edit.addEventListener('click', () => openEditor(name));
       card.appendChild(edit);
+      const dup = document.createElement('button');
+      dup.textContent = 'Duplicate';
+      dup.className = 'duplicate';
+      dup.addEventListener('click', () => duplicateProvider(name));
+      card.appendChild(dup);
       card.addEventListener('dragstart', e => {
         dragEl = card;
         e.dataTransfer?.setData('text/plain', name);

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.30.0" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.31.0" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- allow provider configs to be duplicated and auto-registered via settings UI
- document duplication capability and bump extension version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28a2e76948323bfa11491b9de723b