### PR TITLE
chore: add type declarations and CI typecheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,7 @@ jobs:
           cache: 'npm'
       - name: Install deps
         run: npm install --no-audit --no-fund
+      - name: Type check
+        run: npm run typecheck
       - name: Run unit tests with coverage
         run: npm test -- --coverage

--- a/package.json
+++ b/package.json
@@ -23,6 +23,13 @@
   "license": "AGPL-3.0-or-later",
   "type": "commonjs",
   "types": "types/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "background": ["types/background.d.ts"],
+      "contentScript": ["types/contentScript.d.ts"],
+      "providers/*": ["types/providers/*"]
+    }
+  },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/jest": "^30.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,10 @@
     "skipLibCheck": true,
     "noEmit": true
   },
-  "include": ["types/**/*.d.ts"]
+  "include": [
+    "types/**/*.d.ts",
+    "types/background.d.ts",
+    "types/contentScript.d.ts",
+    "types/providers/**/*.d.ts"
+  ]
 }

--- a/types/background.d.ts
+++ b/types/background.d.ts
@@ -1,0 +1,7 @@
+import type { TranslateOptions } from './index';
+
+export function updateBadge(): void;
+export function setUsingPlus(v: boolean): void;
+export function _setActiveTranslations(n: number): void;
+export function handleTranslate(opts: TranslateOptions & { secondaryModel?: string; parallel?: boolean | 'auto'; provider?: string }): Promise<{ text?: string; confidence?: number; error?: string }>;
+export function _setConfig(cfg: any): void;

--- a/types/contentScript.d.ts
+++ b/types/contentScript.d.ts
@@ -1,0 +1,3 @@
+export function translateBatch(elements: Node[], stats?: any, force?: boolean): Promise<void>;
+export function collectNodes(root: Node, out: Node[]): void;
+export function setCurrentConfig(cfg: any): void;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -49,6 +49,8 @@ export declare const qwenFetchStrategy: {
   setChooser(fn?: (opts?: any) => 'proxy' | 'direct'): void;
 };
 
+export * from './background';
+export * from './contentScript';
 export * from './providers';
 export * from './messaging';
 export * from './tm';

--- a/types/providers/anthropic.d.ts
+++ b/types/providers/anthropic.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/dashscope.d.ts
+++ b/types/providers/dashscope.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/deepl.d.ts
+++ b/types/providers/deepl.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/gemini.d.ts
+++ b/types/providers/gemini.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/google.d.ts
+++ b/types/providers/google.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/index.d.ts
+++ b/types/providers/index.d.ts
@@ -1,16 +1,22 @@
+export interface Provider {
+  translate(opts: any): Promise<{ text: string }>;
+  listModels?(opts?: any): Promise<string[]>;
+  throttle?: { requestLimit: number; windowMs: number; tokenLimit?: number };
+}
+
 export interface ProvidersRegistry {
-  register(id: string, impl: any): void;
-  get(id: string): any;
+  register(id: string, impl: Provider): void;
+  get(id: string): Provider | undefined;
   choose(opts?: { endpoint?: string; provider?: string }): string;
   candidates(opts?: { endpoint?: string; provider?: string }): string[];
-  init(def?: Record<string, any>): boolean;
+  init(def?: Record<string, Provider>): boolean;
   reset(): void;
   isInitialized(): boolean;
 }
 
 export interface ProvidersApi {
-  registerProvider(id: string, impl: any): void;
-  getProvider(id: string): any;
+  registerProvider(id: string, impl: Provider): void;
+  getProvider(id: string): Provider | undefined;
   listProviders(): { name: string; label: string }[];
   initProviders(): void;
   ensureProviders(): boolean;

--- a/types/providers/localWasm.d.ts
+++ b/types/providers/localWasm.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/macos.d.ts
+++ b/types/providers/macos.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/mistral.d.ts
+++ b/types/providers/mistral.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/ollama.d.ts
+++ b/types/providers/ollama.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/openai.d.ts
+++ b/types/providers/openai.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/openrouter.d.ts
+++ b/types/providers/openrouter.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;

--- a/types/providers/qwen.d.ts
+++ b/types/providers/qwen.d.ts
@@ -1,0 +1,4 @@
+import type { Provider } from './index';
+
+declare const provider: Provider;
+export = provider;


### PR DESCRIPTION
## Summary
- add TypeScript declarations for background, content script, and providers
- expose new declarations via package.json and tsconfig
- run `tsc --noEmit` in CI

## Testing
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a28a8837b48323a1dd3061f85c437f