### PR TITLE
feat: display translation progress in viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.33.0",
+      "version": "1.33.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.33.0",
+  "version": "1.33.1",
   "version_name": "2025-08-18",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/src/pdfViewer.js
+++ b/src/pdfViewer.js
@@ -134,6 +134,7 @@ import { storePdfInSession, readPdfFromSession } from './sessionPdf.js';
   const translateProgress = document.createElement('progress');
   translateProgress.max = 1;
   translateProgress.value = 0;
+  translateProgress.className = 'qwen-progress';
   translateProgress.style.position = 'fixed';
   translateProgress.style.top = '0';
   translateProgress.style.left = '0';
@@ -142,6 +143,23 @@ import { storePdfInSession, readPdfFromSession } from './sessionPdf.js';
   translateProgress.style.zIndex = '10000';
   translateProgress.style.display = 'none';
   document.body.appendChild(translateProgress);
+
+  if (chrome?.runtime?.onMessage?.addListener) {
+    chrome.runtime.onMessage.addListener((msg) => {
+      if (msg?.action === 'translation-status' && msg.status) {
+        const { active, progress, phase } = msg.status;
+        if (typeof phase === 'string') translateProgress.dataset.phase = phase;
+        if (active) {
+          translateProgress.style.display = 'block';
+          if (typeof progress === 'number') translateProgress.value = progress;
+        } else {
+          translateProgress.style.display = 'none';
+          translateProgress.value = 0;
+          delete translateProgress.dataset.phase;
+        }
+      }
+    });
+  }
 
   if (window.qwenTranslateBatch) {
     const origBatch = window.qwenTranslateBatch;

--- a/src/styles/apple.css
+++ b/src/styles/apple.css
@@ -114,6 +114,16 @@
   border-radius: 8px;
 }
 
+[data-qwen-theme="apple"] .qwen-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  z-index: 2147483647;
+  display: none;
+}
+
 
 .qwen-hud {
   position: fixed;

--- a/src/styles/cyberpunk.css
+++ b/src/styles/cyberpunk.css
@@ -87,6 +87,35 @@
   background: var(--qwen-secondary-hover);
 }
 
+[data-qwen-theme="cyberpunk"] progress {
+  width: 100%;
+  height: 1rem;
+  -webkit-appearance: none;
+  appearance: none;
+}
+[data-qwen-theme="cyberpunk"] progress::-webkit-progress-bar {
+  background: var(--qwen-secondary-bg);
+  border-radius: 6px;
+}
+[data-qwen-theme="cyberpunk"] progress::-webkit-progress-value {
+  background: var(--qwen-neon-1);
+  border-radius: 6px;
+}
+[data-qwen-theme="cyberpunk"] progress::-moz-progress-bar {
+  background: var(--qwen-neon-1);
+  border-radius: 6px;
+}
+
+[data-qwen-theme="cyberpunk"] .qwen-progress {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 4px;
+  z-index: 2147483647;
+  display: none;
+}
+
 [data-qwen-theme="cyberpunk"] .btn-frame {
   border-color: var(--qwen-neon-1);
   box-shadow: 0 0 4px var(--qwen-neon-1), 0 2px 6px rgba(0, 0, 0, 0.5);

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.33.0" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.33.1" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- show translation progress updates in PDF viewer
- theme progress bar for apple and cyberpunk styles
- test progress overlay with Playwright

## Testing
- `npm test --silent 2>&1 | tail -n 20`
- `npm run test:e2e:pdf`

------
https://chatgpt.com/codex/tasks/task_e_68a2979e39b48323804d02973adf6686