### PR TITLE
chore: add popup type declarations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Type check
         run: npm run typecheck
 
+      - name: Type check popup
+        run: npm run typecheck:popup
+
       - name: Run unit tests
         run: npm test -- --ci --reporters=default
         env:

--- a/package.json
+++ b/package.json
@@ -16,20 +16,22 @@
     "zip": "bestzip dist/qwen-translator-v$npm_package_version.zip dist/*",
     "build:zip": "npm run build && npm run zip",
     "serve": "http-server dist -p 8080",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:popup": "tsc --noEmit types/popup/*.d.ts"
   },
   "keywords": [],
   "author": "",
   "license": "AGPL-3.0-or-later",
   "type": "commonjs",
   "types": "types/index.d.ts",
-  "typesVersions": {
-    "*": {
-      "background": ["types/background.d.ts"],
-      "contentScript": ["types/contentScript.d.ts"],
-      "providers/*": ["types/providers/*"]
-    }
-  },
+    "typesVersions": {
+      "*": {
+        "background": ["types/background.d.ts"],
+        "contentScript": ["types/contentScript.d.ts"],
+      "providers/*": ["types/providers/*"],
+      "popup/*": ["types/popup/*"]
+      }
+    },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/jest": "^30.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,11 @@
     "lib": ["ES2020", "DOM"],
     "strict": true,
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "baseUrl": "./",
+    "paths": {
+      "popup/*": ["src/popup/*"]
+    }
   },
   "include": [
     "types/**/*.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -53,4 +53,5 @@ export * from './background';
 export * from './contentScript';
 export * from './providers';
 export * from './messaging';
+export * from './popup';
 export * from './tm';

--- a/types/popup/diagnostics.d.ts
+++ b/types/popup/diagnostics.d.ts
@@ -1,0 +1,3 @@
+declare module 'popup/diagnostics.js' {
+  export {};
+}

--- a/types/popup/home.d.ts
+++ b/types/popup/home.d.ts
@@ -1,0 +1,3 @@
+declare module 'popup/home.js' {
+  export {};
+}

--- a/types/popup/imports.d.ts
+++ b/types/popup/imports.d.ts
@@ -1,0 +1,4 @@
+import 'popup/home.js';
+import 'popup/settings.js';
+import 'popup/diagnostics.js';
+import 'popup/providerEditor.js';

--- a/types/popup/index.d.ts
+++ b/types/popup/index.d.ts
@@ -1,0 +1,2 @@
+export * from './providerEditor';
+export {};

--- a/types/popup/providerEditor.d.ts
+++ b/types/popup/providerEditor.d.ts
@@ -1,0 +1,15 @@
+declare module 'popup/providerEditor.js' {
+  export {};
+}
+
+export interface QwenProviderEditor {
+  open(id: string, config: any, onDone?: () => void): Promise<void>;
+}
+
+declare global {
+  interface Window {
+    qwenProviderEditor?: QwenProviderEditor;
+  }
+}
+
+export {};

--- a/types/popup/settings.d.ts
+++ b/types/popup/settings.d.ts
@@ -1,0 +1,3 @@
+declare module 'popup/settings.js' {
+  export {};
+}


### PR DESCRIPTION
## Summary
- add type declarations for popup modules and expose ProviderEditor interface
- wire popup declarations into build tooling and CI

## Testing
- `npm run typecheck`
- `npm run typecheck:popup`
- `npm test -- --ci --reporters=default 2>&1 | grep -A5 "Test Suites" | tail -n 7`


------
https://chatgpt.com/codex/tasks/task_e_68a29a0bf4188323b55fd75068b1780b