### PR TITLE
feat: add cyberpunk theme option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.33.1",
+      "version": "1.33.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.1",
+  "version": "1.33.2",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -37,6 +37,7 @@ const defaultCfg = {
   autoOpenAfterSave: true,
   selectionPopup: false,
   theme: 'dark',
+  themeStyle: 'apple',
   charLimit: 0,
   strategy: 'balanced',
   secondaryModel: '',

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.33.1",
-  "version_name": "2025-08-18",
+  "version": "1.33.2",
+  "version_name": "2025-08-19",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [
     "storage",
@@ -44,6 +44,7 @@
         "lib/glossary.js",
         "throttle.js",
         "styles/apple.css",
+        "styles/cyberpunk.css",
         "pdfViewer.html",
         "pdfViewer.js",
         "sessionPdf.js",

--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
+  <link rel="stylesheet" href="../styles/cyberpunk.css">
   <style>
     html {
       background: var(--qwen-bg, rgba(28,28,30,0.7));
@@ -54,7 +55,11 @@
     <select id="destLang"></select>
   </div>
   <div class="theme-select">
-    <label for="theme">Theme</label>
+    <label for="themeStyle">Theme</label>
+    <select id="themeStyle">
+      <option value="apple">Apple</option>
+      <option value="cyberpunk">Cyberpunk</option>
+    </select>
     <select id="theme">
       <option value="dark">Dark</option>
       <option value="light">Light</option>

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
+  <link rel="stylesheet" href="../styles/cyberpunk.css">
   <style>
     html { height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
     body {
@@ -46,10 +47,18 @@
   <div id="generalTab" class="tab">
     <section id="themeSection">
       <h3>Theme</h3>
-      <select id="theme">
-        <option value="dark">Dark</option>
-        <option value="light">Light</option>
-      </select>
+      <label>Style
+        <select id="themeStyle">
+          <option value="apple">Apple</option>
+          <option value="cyberpunk">Cyberpunk</option>
+        </select>
+      </label>
+      <label>Color
+        <select id="theme">
+          <option value="dark">Dark</option>
+          <option value="light">Light</option>
+        </select>
+      </label>
     </section>
     <section id="detectionSection">
       <h3>Language Detection</h3>


### PR DESCRIPTION
## Summary
- allow choosing cyberpunk popup theme and persist style
- apply themeStyle and color data attributes across popup and content
- load cyberpunk stylesheet and bump version

## Testing
- `npm test --silent >/tmp/test.log 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68a29e74cd148323bfea8d194540e15a