### PR TITLE
Add TM management messaging and UI

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -605,6 +605,38 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     sendResponse({ ok: true });
     return true;
   }
+  if (msg.action === 'tm-get-all') {
+    (async () => {
+      const entries = self.qwenTM && self.qwenTM.getAll ? await self.qwenTM.getAll() : [];
+      const stats = self.qwenTM && self.qwenTM.stats ? self.qwenTM.stats() : {};
+      sendResponse({ entries, stats });
+    })();
+    return true;
+  }
+  if (msg.action === 'tm-clear') {
+    (async () => {
+      if (self.qwenTM && self.qwenTM.clear) { await self.qwenTM.clear(); }
+      sendResponse({ ok: true });
+    })();
+    return true;
+  }
+  if (msg.action === 'tm-import') {
+    (async () => {
+      const list = (msg && msg.entries && Array.isArray(msg.entries)) ? msg.entries : [];
+      if (self.qwenTM && self.qwenTM.clear && self.qwenTM.set) {
+        try {
+          await self.qwenTM.clear();
+          for (const item of list) {
+            if (item && typeof item.k === 'string' && typeof item.text === 'string') {
+              await self.qwenTM.set(item.k, item.text);
+            }
+          }
+        } catch {}
+      }
+      sendResponse({ ok: true });
+    })();
+    return true;
+  }
   if (msg.action === 'debug') {
     const cache = {
       size: self.qwenGetCacheSize ? self.qwenGetCacheSize() : 0,

--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -167,7 +167,6 @@
   <script src="../providers/anthropic.js"></script>
   <script src="../providers/localWasm.js"></script>
   <script src="../providers/index.js"></script>
-  <script src="../lib/tm.js"></script>
   <script src="settings.js"></script>
 </body>
 </html>

--- a/test/settings.tmViewer.test.js
+++ b/test/settings.tmViewer.test.js
@@ -1,0 +1,112 @@
+// @jest-environment jsdom
+
+function flush() {
+  return new Promise(res => setTimeout(res, 0));
+}
+
+describe('settings TM viewer', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  test('background exposes tm getAll and clear over messaging', async () => {
+    const syncGet = jest.fn((defs, cb) => cb(defs));
+    global.chrome = {
+      action: { setBadgeText: jest.fn(), setBadgeBackgroundColor: jest.fn(), setIcon: jest.fn() },
+      runtime: { onInstalled: { addListener: jest.fn() }, onMessage: { addListener: jest.fn() }, onConnect: { addListener: jest.fn() } },
+      contextMenus: { create: jest.fn(), removeAll: jest.fn(cb => cb && cb()), onClicked: { addListener: jest.fn() } },
+      tabs: { onUpdated: { addListener: jest.fn() } },
+      storage: { sync: { get: syncGet }, local: { get: jest.fn(), set: jest.fn() } },
+    };
+    global.importScripts = () => {};
+    global.setInterval = () => {};
+    global.self = global;
+    global.qwenThrottle = { configure: jest.fn(), getUsage: () => ({ requests: 0, requestLimit: 60, tokens: 0, tokenLimit: 100000 }), recordUsage: jest.fn() };
+    global.qwenGetCacheSize = () => 0;
+    const tm = {
+      getAll: jest.fn(() => Promise.resolve([{ k: 'a', text: '1' }])),
+      clear: jest.fn(() => Promise.resolve()),
+      set: jest.fn(() => Promise.resolve()),
+      stats: jest.fn(() => ({ entries: 1 })),
+    };
+    global.qwenTM = tm;
+    require('../src/background.js');
+    const listener = chrome.runtime.onMessage.addListener.mock.calls[0][0];
+    const res = await new Promise(resolve => listener({ action: 'tm-get-all' }, {}, resolve));
+    expect(res.entries[0].k).toBe('a');
+    await new Promise(resolve => listener({ action: 'tm-clear' }, {}, resolve));
+    expect(tm.clear).toHaveBeenCalled();
+  });
+
+  test('TM management UI uses messaging actions', async () => {
+    document.body.innerHTML = `
+      <div class="tabs"><button data-tab="general"></button></div>
+      <div id="generalTab">
+        <section id="detectionSection"><input type="checkbox" id="enableDetection"></section>
+        <section id="glossarySection"><textarea id="glossary"></textarea></section>
+      </div>
+      <div id="providersTab" class="tab">
+        <section id="providerSection"><div id="providerList"></div><button id="addProvider"></button></section>
+      </div>
+      <div id="advancedTab">
+        <section id="timeoutSection"><input id="translateTimeoutMs"></section>
+        <section id="cacheSection"><input type="checkbox" id="cacheEnabled"><button id="clearCache"></button></section>
+        <section id="tmSection">
+          <pre id="tmEntries"></pre>
+          <pre id="tmStats"></pre>
+          <button id="tmExport"></button>
+          <input type="file" id="tmImportFile">
+          <button id="tmImport"></button>
+          <button id="tmClear"></button>
+        </section>
+      </div>
+      <div id="diagnosticsTab">
+        <section id="statsDetails"><pre id="usageStats"></pre></section>
+        <section id="tmDetails"><pre id="tmMetrics"></pre></section>
+        <section id="cacheDetails"><pre id="cacheStats"></pre></section>
+      </div>
+    `;
+    let tmEntries = [{ k: 'a', text: '1' }];
+    global.URL.createObjectURL = jest.fn(() => 'blob:1');
+    global.URL.revokeObjectURL = jest.fn();
+    global.chrome = {
+      storage: { sync: { get: jest.fn((defs, cb) => cb(defs)), set: jest.fn() } },
+      runtime: {
+        sendMessage: jest.fn((msg, cb) => {
+          if (msg.action === 'tm-get-all') {
+            cb({ entries: tmEntries, stats: { entries: tmEntries.length } });
+          } else if (msg.action === 'tm-clear') {
+            tmEntries = [];
+            cb({ ok: true });
+          } else if (msg.action === 'tm-import') {
+            tmEntries = msg.entries || [];
+            cb({ ok: true });
+          } else if (msg.action === 'tm-cache-metrics') {
+            cb({ tmMetrics: {}, cacheStats: {} });
+          } else if (msg.action === 'metrics') {
+            cb({ usage: {} });
+          } else {
+            cb({});
+          }
+        }),
+      },
+    };
+    require('../src/popup/settings.js');
+    await flush();
+    expect(document.getElementById('tmEntries').textContent).toContain('"a"');
+    document.getElementById('tmClear').click();
+    await flush();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'tm-clear' }, expect.any(Function));
+    await flush();
+    expect(document.getElementById('tmEntries').textContent).toContain('[]');
+    document.getElementById('tmExport').click();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'tm-get-all' }, expect.any(Function));
+    const fileInput = document.getElementById('tmImportFile');
+    const file = new Blob([JSON.stringify([{ k: 'b', text: '2' }])], { type: 'application/json' });
+    file.text = () => Promise.resolve(JSON.stringify([{ k: 'b', text: '2' }]));
+    Object.defineProperty(fileInput, 'files', { value: [file] });
+    fileInput.dispatchEvent(new Event('change'));
+    await flush();
+    expect(chrome.runtime.sendMessage).toHaveBeenCalledWith({ action: 'tm-import', entries: [{ k: 'b', text: '2' }] }, expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- expose translation memory getAll/clear/import via background messaging
- add popup settings TM management section with export/import/clear wired to messaging
- test TM viewer messaging and UI flows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2a4aa16d883238dd0c3930eff3cc8