### PR TITLE
fix: show realtime diagnostics metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,7 @@
   - Add minimum-signal threshold for very short tokens to reduce misclassification; optional sensitivity setting.
 - Observability
   - Optional background debug endpoint to expose TM/cache metrics; Advanced UI readout in popup.
+  - Diagnostics popup displays real-time throttle usage, cache stats, TM hits, and translation status via `stats` messages.
   - Advanced control for in-memory LRU size (`QWEN_MEMCACHE_MAX`) with validation.
   - Popup diagnostics log each step at info level and content-script batch translations log start/finish for easier troubleshooting.
 - Provider ecosystem

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.33.2",
+      "version": "1.34.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.33.2",
+  "version": "1.34.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/background.js
+++ b/src/background.js
@@ -357,8 +357,16 @@ function getAggregatedStats() {
 
 function broadcastStats() {
   ensureThrottle().then(() => {
-    const stats = getAggregatedStats();
-    safeSendMessage({ action: 'stats', stats });
+    const usage = self.qwenThrottle.getUsage();
+    const cache = {
+      size: cacheStats.size != null ? cacheStats.size : (self.qwenGetCacheSize ? self.qwenGetCacheSize() : 0),
+      max: cacheStats.max != null ? cacheStats.max : ((self.qwenConfig && self.qwenConfig.memCacheMax) || 0),
+      hits: cacheStats.hits || 0,
+      misses: cacheStats.misses || 0,
+      hitRate: cacheStats.hitRate || 0,
+    };
+    const tm = Object.keys(tmStats).length ? tmStats : ((self.qwenTM && self.qwenTM.stats) ? self.qwenTM.stats() : {});
+    safeSendMessage({ action: 'stats', usage, cache, tm });
   });
 }
 

--- a/src/popup/diagnostics.html
+++ b/src/popup/diagnostics.html
@@ -14,6 +14,7 @@
 </head>
 <body>
   <h3>Diagnostics</h3>
+  <div class="section" id="status"></div>
   <div class="section" id="usage"></div>
   <div class="section" id="usageSummary"></div>
   <canvas id="usageChart"></canvas>

--- a/test/diagnosticsChart.test.js
+++ b/test/diagnosticsChart.test.js
@@ -5,6 +5,7 @@ describe('diagnostics chart', () => {
   beforeEach(() => {
     jest.resetModules();
     document.body.innerHTML = `
+      <div id="status"></div>
       <div id="usage"></div>
       <div id="usageSummary"></div>
       <canvas id="usageChart"></canvas>
@@ -17,7 +18,10 @@ describe('diagnostics chart', () => {
     global.chrome = {
       storage: { local: { get: jest.fn((_, cb) => cb({ usageLog: [{ ts: 1, tokens: 2, latency: 3 }] })) } },
       runtime: {
-        sendMessage: jest.fn((msg, cb) => { if (msg.action === 'metrics') cb({ providers: { qwen: { apiKey: true } }, usage: {}, cache: {}, tm: {} }); }),
+        sendMessage: jest.fn((msg, cb) => {
+          if (msg.action === 'metrics') cb({ providers: { qwen: { apiKey: true } }, usage: {}, cache: {}, tm: {} });
+          else if (msg.action === 'get-status') cb({ active: false });
+        }),
         onMessage: { addListener: fn => { listener = fn; } }
       }
     };
@@ -31,5 +35,13 @@ describe('diagnostics chart', () => {
   test('updates on usage-metrics message', () => {
     listener({ action: 'usage-metrics', data: { ts: 2, tokens: 3, latency: 4 } });
     expect(document.getElementById('usageSummary').textContent).toContain('Requests: 2');
+  });
+
+  test('updates on stats and translation-status messages', () => {
+    listener({ action: 'stats', usage: { requests: 5, requestLimit: 10, tokens: 20, tokenLimit: 100 }, cache: { size: 1, max: 2 }, tm: { hits: 3, misses: 4 } });
+    expect(document.getElementById('usage').textContent).toContain('Requests 5/10');
+    expect(document.getElementById('cache').textContent).toContain('TM hits 3');
+    listener({ action: 'translation-status', status: { active: true } });
+    expect(document.getElementById('status').textContent).toBe('Translating…');
   });
 });


### PR DESCRIPTION
## Summary
- broadcast live usage, cache, and TM metrics from background script
- show active translation status and quota/cache/TM updates in diagnostics popup
- test realtime diagnostics updates and bump version to 1.34.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ab72ddf08323971e445f9a88191c