### PR TITLE
fix: guard module usage in config to avoid ReferenceError

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.34.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.34.0",
+      "version": "1.35.1",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {
@@ -24,14 +24,22 @@
   "license": "AGPL-3.0-or-later",
   "type": "commonjs",
   "types": "types/index.d.ts",
-    "typesVersions": {
-      "*": {
-        "background": ["types/background.d.ts"],
-        "contentScript": ["types/contentScript.d.ts"],
-      "providers/*": ["types/providers/*"],
-      "popup/*": ["types/popup/*"]
-      }
-    },
+  "typesVersions": {
+    "*": {
+      "background": [
+        "types/background.d.ts"
+      ],
+      "contentScript": [
+        "types/contentScript.d.ts"
+      ],
+      "providers/*": [
+        "types/providers/*"
+      ],
+      "popup/*": [
+        "types/popup/*"
+      ]
+    }
+  },
   "devDependencies": {
     "@playwright/test": "^1.54.2",
     "@types/jest": "^30.0.0",

--- a/src/config.js
+++ b/src/config.js
@@ -166,8 +166,10 @@ function qwenSaveConfig(cfg) {
   return Promise.resolve(); // Otherwise, do nothing
 }
 
+const exportsObj = { qwenLoadConfig, qwenSaveConfig, defaultCfg, modelTokenLimits, TRANSLATE_TIMEOUT_MS };
+
 if (typeof module !== 'undefined') {
-  module.exports = { qwenLoadConfig, qwenSaveConfig, defaultCfg, modelTokenLimits, TRANSLATE_TIMEOUT_MS };
+  module.exports = exportsObj;
 }
 if (typeof window !== 'undefined') {
   window.qwenDefaultConfig = defaultCfg;
@@ -181,7 +183,7 @@ if (typeof window !== 'undefined') {
     chrome.runtime &&
     chrome.runtime.id
   ) {
-    window.__qwenConfigModule = module.exports;
+    window.__qwenConfigModule = exportsObj;
   }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Qwen Translator",
   "description": "Translate pages using Qwen-MT-Turbo",
-  "version": "1.33.2",
+  "version": "1.33.3",
   "version_name": "2025-08-19",
   "update_url": "https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/updates.xml",
   "permissions": [

--- a/updates.xml
+++ b/updates.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
   <app appid="YOUR_EXTENSION_ID">
-    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.33.1" />
+    <updatecheck codebase="https://raw.githubusercontent.com/MikkoParkkola/Qwen-translator-extension/main/qwen-translator-extension.crx" version="1.33.3" />
   </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- avoid referencing `module` when undefined in config
- bump extension version to 1.33.3 / package to 1.35.1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ccc430648323a762672184b46116