### PR TITLE
test: restore navigator.onLine descriptor

### DIFF
--- a/test/fetchStrategy.test.js
+++ b/test/fetchStrategy.test.js
@@ -17,11 +17,10 @@ test('returns local when provider is local-wasm', () => {
 });
 
 test('returns local when offline', () => {
-  const orig = global.navigator;
-  Object.defineProperty(global, 'navigator', { value: { onLine: false }, configurable: true });
+  const origDesc = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(global.navigator), 'onLine');
+  Object.defineProperty(global.navigator, 'onLine', { value: false, configurable: true });
   expect(choose({})).toBe('local');
-  if (orig) Object.defineProperty(global, 'navigator', { value: orig });
-  else delete global.navigator;
+  Object.defineProperty(global.navigator, 'onLine', origDesc);
 });
 
 test('setChooser overrides selection', () => {


### PR DESCRIPTION
## Summary
- mock offline state by overriding `navigator.onLine`
- restore original `navigator.onLine` descriptor after offline tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2d294150c8323a5aa1140f175efe2