### PR TITLE
fix: improve provider editor selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.35.1",
+      "version": "1.35.2",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.35.1",
+  "version": "1.35.2",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/popup/providerEditor.html
+++ b/src/popup/providerEditor.html
@@ -2,13 +2,17 @@
   <div style="background:var(--qwen-bg,rgba(28,28,30,0.9));padding:1rem;border:1px solid var(--qwen-border,rgba(255,255,255,0.2));min-width:260px;">
     <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
     <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
-    <label data-field="model">Model <input id="pe_model" list="pe_modelList"><datalist id="pe_modelList"></datalist></label>
+    <label data-field="model">Model <select id="pe_modelSelect" style="display:none"></select><input id="pe_modelInput"></label>
     <details id="pe_advanced">
       <summary>Advanced</summary>
       <label data-field="requestLimit">Requests/min <input id="pe_requestLimit" type="number" min="0"></label>
       <label data-field="tokenLimit">Tokens/min <input id="pe_tokenLimit" type="number" min="0"></label>
       <label data-field="charLimit">Chars/month <input id="pe_charLimit" type="number" min="0"></label>
-      <label data-field="strategy">Strategy <input id="pe_strategy"></label>
+      <label data-field="strategy">Strategy <select id="pe_strategy">
+        <option value="balanced" title="Balance cost and speed">Balanced</option>
+        <option value="fast" title="Prefer fastest provider">Fast</option>
+        <option value="cheap" title="Prefer lowest cost provider">Cheap</option>
+      </select></label>
       <label data-field="costPerInputToken" title="Cost per million input tokens in USD">Input cost per 1M tokens (USD) <input id="pe_costPerInputToken" type="number" step="0.01" min="0"></label>
       <label data-field="costPerOutputToken" title="Cost per million output tokens in USD">Output cost per 1M tokens (USD) <input id="pe_costPerOutputToken" type="number" step="0.01" min="0"></label>
       <label data-field="weight" title="Relative load-balancing preference when multiple providers are available">Weight <input id="pe_weight" type="number" step="0.01" min="0"></label>

--- a/src/providers/deepl.js
+++ b/src/providers/deepl.js
@@ -51,7 +51,7 @@
       return {
         translate: opts => translate({ ...opts, endpoint: ep || opts.endpoint }),
         label: 'DeepL',
-        configFields: ['apiKey', 'apiEndpoint', 'model'],
+        configFields: ['apiKey', 'apiEndpoint'],
         throttle: { requestLimit: 15, windowMs: 1000 },
       };
     }


### PR DESCRIPTION
## Summary
- make strategy selectable with tooltip options
- switch model input to dropdown when provider lists models
- resize popup to fit provider editor
- remove model field from DeepL provider
- bump version to 1.35.2

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2f1383c988323aab13f0b8475384a