### PR TITLE
fix: guard isOfflineError for missing navigator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.35.2",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.35.2",
+      "version": "1.36.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.35.2",
+  "version": "1.36.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/lib/offline.js
+++ b/src/lib/offline.js
@@ -1,5 +1,6 @@
 function isOfflineError(err) {
-  return !navigator.onLine || (err && /network|fetch/i.test(err.message || ''));
+  const online = globalThis.navigator?.onLine ?? true;
+  return !online || (err && /network|fetch/i.test(err.message || ''));
 }
 
 if (typeof module !== 'undefined') module.exports = { isOfflineError };

--- a/test/isOfflineError.test.js
+++ b/test/isOfflineError.test.js
@@ -1,5 +1,18 @@
 const { isOfflineError } = require('../src/lib/offline.js');
 
-test('detects network errors', () => {
-  expect(isOfflineError(new Error('Failed to fetch'))).toBe(true);
+describe('isOfflineError', () => {
+  test('detects network errors', () => {
+    expect(isOfflineError(new Error('Failed to fetch'))).toBe(true);
+  });
+
+  test('handles missing navigator', () => {
+    const original = global.navigator;
+    try {
+      delete global.navigator;
+      expect(isOfflineError(new Error('Failed to fetch'))).toBe(true);
+      expect(isOfflineError(new Error('Oops'))).toBe(false);
+    } finally {
+      global.navigator = original;
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- streamline navigator check in `isOfflineError`
- test network detection without `navigator`
- bump version to 1.36.0

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a31917eb64832381f47d9db06ed43f