### PR TITLE
Guard module reference in config

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -183,7 +183,7 @@ if (typeof window !== 'undefined') {
     chrome.runtime &&
     chrome.runtime.id
   ) {
-    window.__qwenConfigModule = exportsObj;
+    window.__qwenConfigModule = typeof module !== 'undefined' ? module.exports : exportsObj;
   }
 }
 


### PR DESCRIPTION
## Summary
- guard window.__qwenConfigModule assignment to avoid undefined `module`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a32af6a68c83238b8e78ce5a783d69