### PR TITLE
test: stabilize selection error message test

### DIFF
--- a/test/contentScript.test.js
+++ b/test/contentScript.test.js
@@ -257,13 +257,13 @@ test('translate-selection error uses localized message', async () => {
   sel.removeAllRanges();
   sel.addRange(range);
   messageListener({ action: 'translate-selection' });
-  let status;
-  for (let i = 0; i < 5; i++) {
-    status = document.getElementById('qwen-status');
-    if (status) break;
+  await new Promise(r => setTimeout(r, 0));
+  let status = document.getElementById('qwen-status');
+  for (let i = 0; i < 5 && !status; i++) {
     // allow queued microtasks and timers to run
     // eslint-disable-next-line no-await-in-loop
     await new Promise(r => setTimeout(r, 0));
+    status = document.getElementById('qwen-status');
   }
   expect(status && status.textContent).toBe('Qwen Translator: Localized fail: oops');
 });


### PR DESCRIPTION
## Summary
- stabilize translate-selection localized error test by waiting for status element to appear

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a339b5eac08323a2a374de13a98aac