### PR TITLE
feat: handle Google provider selection

### DIFF
--- a/src/lib/providers.js
+++ b/src/lib/providers.js
@@ -27,6 +27,7 @@
       if (ep.includes('openai')) return 'openai';
       if (ep.includes('deepl')) return 'deepl';
       if (ep.includes('dashscope')) return 'dashscope';
+      if (ep.includes('google')) return 'google';
       return 'dashscope';
     }
     function candidates(opts = {}) {

--- a/src/translator.js
+++ b/src/translator.js
@@ -251,7 +251,7 @@ function chooseProvider(opts) {
   const ep = String(opts && opts.endpoint || '').toLowerCase();
   return ep.includes('dashscope') ? 'dashscope' : 'dashscope';
 }
-async function providerTranslate({ endpoint, apiKey, model, text, source, target, tone, signal, debug, onData, stream = true, provider, context = 'default', autoInit = false, providerOrder, endpoints, secondaryModel }) {
+async function providerTranslate({ endpoint, apiKey, projectId, location, model, text, source, target, tone, signal, debug, onData, stream = true, provider, context = 'default', autoInit = false, providerOrder, endpoints, secondaryModel }) {
   _ensureProviders({ autoInit });
   const tokens = approxTokens(text);
   let chain;
@@ -281,7 +281,7 @@ async function providerTranslate({ endpoint, apiKey, model, text, source, target
     try {
       const t = throttleFor(id, context);
       return await t.runWithRetry(
-        () => impl.translate({ endpoint: ep, apiKey, model, secondaryModel, text, source, target, tone, signal, debug, onData, stream }),
+        () => impl.translate({ endpoint: ep, apiKey, projectId, location, model, secondaryModel, text, source, target, tone, signal, debug, onData, stream }),
         tokens,
         3,
         debug
@@ -436,7 +436,7 @@ async function doFetch({ endpoint, apiKey, model, text, source, target, tone, si
   return { text: result };
 }
 
-async function qwenTranslate({ endpoint, apiKey, model, secondaryModel, text, source, target, signal, debug = false, stream = false, noProxy = false, provider, detector, force = false, skipTM = false, autoInit = false, providerOrder, endpoints, sensitivity = 0, failover = true }) {
+async function qwenTranslate({ endpoint, apiKey, projectId, location, model, secondaryModel, text, source, target, signal, debug = false, stream = false, noProxy = false, provider, detector, force = false, skipTM = false, autoInit = false, providerOrder, endpoints, sensitivity = 0, failover = true }) {
   if (debug) {
     trLogger.debug('qwenTranslate called with', {
       endpoint,
@@ -501,7 +501,7 @@ async function qwenTranslate({ endpoint, apiKey, model, secondaryModel, text, so
     }
 
   try {
-    const data = await providerTranslate({ endpoint, apiKey, model, text, source: src, target, tone, signal, debug, stream, provider: provider ? prov : undefined, context: stream ? 'stream' : 'default', autoInit, providerOrder: failover ? providerOrder : undefined, endpoints, secondaryModel });
+    const data = await providerTranslate({ endpoint, apiKey, projectId, location, model, text, source: src, target, tone, signal, debug, stream, provider: provider ? prov : undefined, context: stream ? 'stream' : 'default', autoInit, providerOrder: failover ? providerOrder : undefined, endpoints, secondaryModel });
     _setCache(cacheKey, data);
     if (!skipTM && TM && TM.set && data && typeof data.text === 'string') { try { TM.set(cacheKey, data.text); } catch {} }
     if (debug) {
@@ -515,7 +515,7 @@ async function qwenTranslate({ endpoint, apiKey, model, secondaryModel, text, so
   }
 }
 
-async function qwenTranslateStream({ endpoint, apiKey, model, secondaryModel, text, source, target, signal, debug = false, stream = true, noProxy = false, provider, detector, skipTM = false, autoInit = false, providerOrder, endpoints, sensitivity = 0, failover = true }, onData) {
+async function qwenTranslateStream({ endpoint, apiKey, projectId, location, model, secondaryModel, text, source, target, signal, debug = false, stream = true, noProxy = false, provider, detector, skipTM = false, autoInit = false, providerOrder, endpoints, sensitivity = 0, failover = true }, onData) {
   if (debug) {
     trLogger.debug('qwenTranslateStream called with', {
       endpoint,
@@ -572,7 +572,7 @@ async function qwenTranslateStream({ endpoint, apiKey, model, secondaryModel, te
     }
 
   try {
-    const data = await providerTranslate({ endpoint, apiKey, model, text, source: src, target, tone, signal, debug, onData, stream, provider: prov, context: 'stream', autoInit, providerOrder: failover ? providerOrder : undefined, endpoints, secondaryModel });
+    const data = await providerTranslate({ endpoint, apiKey, projectId, location, model, text, source: src, target, tone, signal, debug, onData, stream, provider: prov, context: 'stream', autoInit, providerOrder: failover ? providerOrder : undefined, endpoints, secondaryModel });
     _setCache(cacheKey, data);
     if (!skipTM && TM && TM.set && data && typeof data.text === 'string') { try { TM.set(cacheKey, data.text); } catch {} }
     if (debug) {

--- a/test/provider.selection.test.js
+++ b/test/provider.selection.test.js
@@ -46,6 +46,31 @@ describe('provider selection', () => {
     expect(openai.translate).toHaveBeenCalled();
   });
 
+  test('auto-selects by endpoint (google)', async () => {
+    const Providers = require('../src/lib/providers.js');
+    const google = { translate: jest.fn(async ({ text }) => ({ text: `GO:${text}` })) };
+    Providers.register('google', google);
+    Providers.init();
+    const { qwenTranslate } = require('../src/translator.js');
+
+    const res = await qwenTranslate({
+      text: 'hello',
+      source: 'en',
+      target: 'es',
+      endpoint: 'https://translation.googleapis.com',
+      apiKey: 'k',
+      projectId: 'p',
+      location: 'l',
+      noProxy: true,
+    });
+
+    expect(res).toBeDefined();
+    expect(res.text).toBe('GO:hello');
+    expect(google.translate).toHaveBeenCalledWith(
+      expect.objectContaining({ apiKey: 'k', projectId: 'p', location: 'l' })
+    );
+  });
+
   test('respects providerOrder with endpoints', async () => {
     const Providers = require('../src/lib/providers.js');
     const bad = {


### PR DESCRIPTION
## Summary
- include Google in provider auto-selection
- forward project configuration to translation providers
- test provider choice with Google endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a3ac3e5adc8323950d855ba2a607ad