### PR TITLE
test: extend provider registry coverage

### DIFF
--- a/test/providers.registry.test.js
+++ b/test/providers.registry.test.js
@@ -6,3 +6,25 @@ test('createRegistry returns isolated registries', () => {
   r1.register('a', { translate: () => {} });
   expect(r2.get('a')).toBeUndefined();
 });
+
+test('candidates returns chosen provider first without duplicates', () => {
+  const r = createRegistry();
+  r.register('a', { translate: () => {} });
+  r.register('b', { translate: () => {} });
+  r.register('c', { translate: () => {} });
+  const order = r.candidates({ provider: 'b' });
+  expect(order).toEqual(['b', 'a', 'c']);
+  expect(new Set(order).size).toBe(order.length);
+});
+
+test('reset clears providers and initialization state', () => {
+  const r = createRegistry();
+  r.register('a', { translate: () => {} });
+  expect(r.isInitialized()).toBe(false);
+  r.init();
+  expect(r.isInitialized()).toBe(true);
+  r.reset();
+  expect(r.isInitialized()).toBe(false);
+  expect(r.get('a')).toBeUndefined();
+  expect(r.candidates()).toEqual([]);
+});


### PR DESCRIPTION
## Summary
- expand provider registry tests to cover candidates ordering and uniqueness
- test registry reset and initialization state handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46f4967c48323a7103ab46d99ea0e