### PR TITLE
Add provider failover test for partial success scenario

### DIFF
--- a/test/provider.failover.test.js
+++ b/test/provider.failover.test.js
@@ -44,7 +44,7 @@
      expect(dashscope.translate).toHaveBeenCalledTimes(1);
    });
 
-   test('falls back on non-retryable error without extra retries', async () => {
+  test('falls back on non-retryable error without extra retries', async () => {
      const Providers = require('../src/lib/providers.js');
 
      const openai = {
@@ -77,6 +77,58 @@
      expect(res).toEqual({ text: 'OK:hola' });
      // non-retryable -> single call, then fallback
      expect(openai.translate).toHaveBeenCalledTimes(1);
-     expect(dashscope.translate).toHaveBeenCalledTimes(1);
-   });
- });
+    expect(dashscope.translate).toHaveBeenCalledTimes(1);
+  });
+
+  test('after initial success, retries and fails over on later retryable error', async () => {
+    const Providers = require('../src/lib/providers.js');
+
+    let attempt = 0;
+    const openai = {
+      translate: jest.fn(async ({ text }) => {
+        if (attempt++ === 0) return { text: `OK:${text}` };
+        const e = new Error('rate limited');
+        e.retryable = true;
+        e.retryAfter = 1;
+        throw e;
+      }),
+    };
+    const dashscope = {
+      translate: jest.fn(async ({ text }) => ({ text: `F:${text}` })),
+    };
+
+    Providers.register('openai', openai);
+    Providers.register('dashscope', dashscope);
+    Providers.init();
+    const { qwenTranslate } = require('../src/translator.js');
+
+    const first = await qwenTranslate({
+      text: 'first',
+      source: 'en',
+      target: 'es',
+      endpoint: 'https://api.openai.com/v1',
+      model: 'm',
+      debug: false,
+      stream: false,
+      noProxy: true,
+    });
+    expect(first).toEqual({ text: 'OK:first' });
+    expect(openai.translate).toHaveBeenCalledTimes(1);
+    expect(dashscope.translate).toHaveBeenCalledTimes(0);
+
+    const second = await qwenTranslate({
+      text: 'second',
+      source: 'en',
+      target: 'es',
+      endpoint: 'https://api.openai.com/v1',
+      model: 'm',
+      debug: false,
+      stream: false,
+      noProxy: true,
+    });
+    expect(second).toEqual({ text: 'F:second' });
+    // first call + 3 retry attempts on second call
+    expect(openai.translate).toHaveBeenCalledTimes(4);
+    expect(dashscope.translate).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- extend provider failover tests to cover initial success followed by failover

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46f63e2008323bc9baa0a29ca31b4