### PR TITLE
feat: improve settings tab accessibility

### DIFF
--- a/src/popup/settings.html
+++ b/src/popup/settings.html
@@ -55,11 +55,11 @@
   </style>
 </head>
 <body>
-  <div class="tabs">
-    <button data-tab="general">General</button>
-    <button data-tab="providers">Providers</button>
-    <button data-tab="advanced">Advanced</button>
-    <button data-tab="diagnostics">Diagnostics</button>
+  <div class="tabs" role="tablist">
+    <button data-tab="general" role="tab" aria-controls="generalTab">General</button>
+    <button data-tab="providers" role="tab" aria-controls="providersTab">Providers</button>
+    <button data-tab="advanced" role="tab" aria-controls="advancedTab">Advanced</button>
+    <button data-tab="diagnostics" role="tab" aria-controls="diagnosticsTab">Diagnostics</button>
   </div>
 
   <div id="generalTab" class="tab">

--- a/src/popup/settings.js
+++ b/src/popup/settings.js
@@ -68,7 +68,12 @@
   document.body.style.width = `${fixedWidth}px`;
 
   function activate(tab) {
-    tabs.forEach(b => b.classList.toggle('active', b.dataset.tab === tab));
+    tabs.forEach(b => {
+      const active = b.dataset.tab === tab;
+      b.classList.toggle('active', active);
+      b.setAttribute('aria-selected', active ? 'true' : 'false');
+      b.setAttribute('tabindex', active ? '0' : '-1');
+    });
     Object.entries(sections).forEach(([k, el]) => {
       el.classList.toggle('active', k === tab);
     });
@@ -76,10 +81,22 @@
   }
 
   activate(store.settingsTab);
-  tabs.forEach(btn => btn.addEventListener('click', () => {
-    activate(btn.dataset.tab);
-    chrome?.storage?.sync?.set({ settingsTab: btn.dataset.tab });
-  }));
+  tabs.forEach((btn, idx) => {
+    btn.addEventListener('click', () => {
+      activate(btn.dataset.tab);
+      chrome?.storage?.sync?.set({ settingsTab: btn.dataset.tab });
+    });
+    btn.addEventListener('keydown', e => {
+      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+        e.preventDefault();
+        const dir = e.key === 'ArrowRight' ? 1 : -1;
+        const newIdx = (idx + dir + tabs.length) % tabs.length;
+        const newTab = tabs[newIdx];
+        newTab.click();
+        newTab.focus();
+      }
+    });
+  });
 
   const detectBox = document.getElementById('enableDetection');
   detectBox.checked = store.enableDetection;


### PR DESCRIPTION
## Summary
- expose settings tabs as a tablist with tab buttons linked to panels
- update activation logic to set aria-selected and tabindex
- support keyboard navigation between tabs via arrow keys

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a47e2bb2808323ab96e193696d6c18