### PR TITLE
Cache Playwright browsers in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,8 +25,19 @@ jobs:
       - name: Install deps
         run: npm ci --no-audit --no-fund
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          echo "version=$(node -p \"require('playwright/package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('playwright.config.js') }}
+
       - name: Install Playwright Browsers
-        run: npx playwright install --with-deps
+        run: npx playwright install chromium
 
       - name: Check repo for public PDFs at root (privacy)
         run: |


### PR DESCRIPTION
## Summary
- download only Chromium for e2e tests
- cache Playwright browser binaries for faster CI runs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a48260feb483238178079c82cb3bdb