### PR TITLE
test: run e2e smoke on Firefox and WebKit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,8 +86,8 @@ jobs:
           name: dist
           path: .
 
-      - name: Install Playwright (Chromium + deps)
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Start static server
         run: |
@@ -97,7 +97,7 @@ jobs:
           done
 
       - name: Run e2e tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --browser=chromium,firefox,webkit
 
       - name: Upload Playwright report
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -47,8 +47,8 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}-${{ hashFiles('playwright.config.js') }}
 
-      - name: Install Playwright Browsers
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Check repo for public PDFs at root (privacy)
         run: |
@@ -61,6 +61,6 @@ jobs:
           fi
 
       - name: Run E2E tests
-        run: npm run test:e2e
+        run: npm run test:e2e -- --browser=chromium,firefox,webkit
 
       # Privacy: do not upload screenshots or artifacts by default to avoid exposing PDFs/PII

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -9,6 +9,11 @@ const config = {
     viewport: { width: 1200, height: 900 },
   },
   testDir: 'e2e',
+  projects: [
+    { name: 'chromium', use: { browserName: 'chromium' } },
+    { name: 'firefox', use: { browserName: 'firefox' } },
+    { name: 'webkit', use: { browserName: 'webkit' } },
+  ],
   webServer: {
     command: "npx http-server -p 8080 -c-1 . -H 'Permissions-Policy: accelerometer=(), ambient-light-sensor=(), autoplay=(), battery=()'",
     url: 'http://127.0.0.1:8080',


### PR DESCRIPTION
## Summary
- run Playwright projects for chromium, firefox, and webkit
- smoke test Firefox and WebKit in CI
- ensure manual E2E workflow installs all browsers

## Testing
- `npm test`
- `npx playwright test --project=firefox --project=webkit`


------
https://chatgpt.com/codex/tasks/task_e_68a48b0c0e348323815606f77e4ab3a4