### PR TITLE
feat: add provider cards to popup

### DIFF
--- a/src/popup/home.html
+++ b/src/popup/home.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <link rel="stylesheet" href="../styles/apple.css">
   <link rel="stylesheet" href="../styles/cyberpunk.css">
+  <link rel="stylesheet" href="../styles/popup.css">
   <style>
     html {
       background: var(--qwen-bg, rgba(28,28,30,0.7));

--- a/src/popup/home.js
+++ b/src/popup/home.js
@@ -139,28 +139,38 @@
     Object.entries(providers).forEach(([name, p]) => {
       const card = document.createElement('div');
       card.className = 'provider-card';
-      card.style.display = 'flex';
-      card.style.flexDirection = 'column';
-      card.style.gap = '4px';
-      const title = document.createElement('div');
-      title.style.fontWeight = '600';
+
+      const header = document.createElement('div');
+      header.className = 'provider-card-title';
+      const avatar = document.createElement('span');
+      avatar.className = 'provider-avatar';
+      avatar.textContent = name.slice(0, 1).toUpperCase();
+      const title = document.createElement('span');
       title.textContent = name;
+      header.appendChild(avatar);
+      header.appendChild(title);
       const req = document.createElement('div');
       req.textContent = `Requests ${p.requests || 0}/${usage.requestLimit || 0}`;
       const reqBar = document.createElement('progress');
       reqBar.max = usage.requestLimit || 0;
       reqBar.value = p.requests || 0;
+      if (self.qwenUsageColor) {
+        reqBar.style.accentColor = self.qwenUsageColor(reqBar.value / (reqBar.max || 1));
+      }
       const tok = document.createElement('div');
       tok.textContent = `Tokens ${p.tokens || 0}/${usage.tokenLimit || 0}`;
       const tokBar = document.createElement('progress');
       tokBar.max = usage.tokenLimit || 0;
       tokBar.value = p.tokens || 0;
+      if (self.qwenUsageColor) {
+        tokBar.style.accentColor = self.qwenUsageColor(tokBar.value / (tokBar.max || 1));
+      }
       const small = document.createElement('div');
       small.className = 'stats';
       const total = `Total ${p.totalRequests || 0} req • ${p.totalTokens || 0} tok`;
       const avoid = `Saved ${p.avoidedRequests || 0} req • ${p.avoidedTokens || 0} tok`;
       small.textContent = `${total} • ${avoid}`;
-      card.appendChild(title);
+      card.appendChild(header);
       card.appendChild(req);
       card.appendChild(reqBar);
       card.appendChild(tok);

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -1,0 +1,38 @@
+#providers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.provider-card {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 0.5rem;
+  border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
+  flex: 1 1 150px;
+}
+
+.provider-card:hover {
+  background: var(--qwen-secondary-bg, rgba(118,118,128,0.2));
+}
+
+.provider-card-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.provider-avatar {
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 50%;
+  background: var(--qwen-secondary-bg, rgba(118,118,128,0.2));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-transform: uppercase;
+}


### PR DESCRIPTION
## Summary
- add provider-card stylesheet for popup provider usage
- render provider cards with initials and usage-colored progress bars

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4967982c483239e96e8aa918ed483