### PR TITLE
Add snapshot tests for apple theme

### DIFF
--- a/test/styles/__snapshots__/theme.snapshot.test.js.snap
+++ b/test/styles/__snapshots__/theme.snapshot.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`apple theme snapshots dark mode 1`] = `
+{
+  "--qwen-bg": "rgba(28, 28, 30, 0.7)",
+  "--qwen-border": "rgba(255, 255, 255, 0.2)",
+  "--qwen-error": "#ff3b30",
+  "--qwen-input-bg": "rgba(255, 255, 255, 0.1)",
+  "--qwen-input-focus": "#0a84ff",
+  "--qwen-primary-bg": "#0a84ff",
+  "--qwen-primary-hover": "#0060df",
+  "--qwen-secondary-bg": "rgba(118, 118, 128, 0.2)",
+  "--qwen-secondary-hover": "rgba(118, 118, 128, 0.3)",
+  "--qwen-text": "#f5f5f7",
+}
+`;
+
+exports[`apple theme snapshots light mode 1`] = `
+{
+  "--qwen-bg": "rgba(255, 255, 255, 0.75)",
+  "--qwen-border": "rgba(0, 0, 0, 0.1)",
+  "--qwen-error": "#ff3b30",
+  "--qwen-input-bg": "rgba(255, 255, 255, 0.9)",
+  "--qwen-input-focus": "#0a84ff",
+  "--qwen-primary-bg": "#0a84ff",
+  "--qwen-primary-hover": "#0060df",
+  "--qwen-secondary-bg": "rgba(118, 118, 128, 0.12)",
+  "--qwen-secondary-hover": "rgba(118, 118, 128, 0.2)",
+  "--qwen-text": "#1c1c1e",
+}
+`;

--- a/test/styles/theme.snapshot.test.js
+++ b/test/styles/theme.snapshot.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('apple theme snapshots', () => {
+  const vars = [
+    '--qwen-bg',
+    '--qwen-text',
+    '--qwen-border',
+    '--qwen-error',
+    '--qwen-input-bg',
+    '--qwen-input-focus',
+    '--qwen-primary-bg',
+    '--qwen-primary-hover',
+    '--qwen-secondary-bg',
+    '--qwen-secondary-hover',
+  ];
+
+  beforeAll(() => {
+    const css = fs.readFileSync(path.resolve(__dirname, '../../src/styles/apple.css'), 'utf8');
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+  });
+
+  const snapshotFor = el => {
+    const computed = getComputedStyle(el);
+    const out = {};
+    for (const v of vars) {
+      out[v] = computed.getPropertyValue(v).trim();
+    }
+    return out;
+  };
+
+  test('dark mode', () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-qwen-theme', 'apple');
+    document.body.appendChild(el);
+    expect(snapshotFor(el)).toMatchSnapshot();
+  });
+
+  test('light mode', () => {
+    const el = document.createElement('div');
+    el.setAttribute('data-qwen-theme', 'apple');
+    el.setAttribute('data-qwen-color', 'light');
+    document.body.appendChild(el);
+    expect(snapshotFor(el)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## Summary
- add snapshot tests for apple.css theme variables in dark and light modes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a46fcb0d508323b5fb488bab88ea65