### PR TITLE
fix: wrap popup content to avoid horizontal scrolling

### DIFF
--- a/dist/popup/diagnostics.html
+++ b/dist/popup/diagnostics.html
@@ -5,7 +5,7 @@
   <link rel="stylesheet" href="../styles/apple.css">
   <style>
     html { min-height: 100%; background: var(--qwen-bg, rgba(28,28,30,0.7)); }
-    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); }
+    body { font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,"Helvetica Neue",Arial,sans-serif; margin:0; padding:1rem; color:var(--qwen-text,#f5f5f7); overflow-x:hidden; overflow-wrap:anywhere; }
     ul { list-style: none; padding: 0; }
     li { margin-bottom: 0.25rem; }
     .section { margin-bottom: 0.5rem; }

--- a/dist/popup/home.html
+++ b/dist/popup/home.html
@@ -16,6 +16,8 @@
       display: flex;
       flex-direction: column;
       gap: 0.75rem;
+      overflow-x: hidden;
+      overflow-wrap: anywhere;
     }
     .auto-toggle {
       display: flex;

--- a/dist/popup/providerEditor.html
+++ b/dist/popup/providerEditor.html
@@ -1,5 +1,5 @@
-<div id="providerEditorOverlay" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);display:none;align-items:center;justify-content:center;z-index:1000;">
-  <div style="background:var(--qwen-bg,rgba(28,28,30,0.9));padding:1rem;border:1px solid var(--qwen-border,rgba(255,255,255,0.2));min-width:260px;">
+<div id="providerEditorOverlay" style="position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.6);display:none;align-items:center;justify-content:center;z-index:1000;overflow-x:hidden;overflow-wrap:anywhere;">
+  <div style="background:var(--qwen-bg,rgba(28,28,30,0.9));padding:1rem;border:1px solid var(--qwen-border,rgba(255,255,255,0.2));min-width:260px;overflow-wrap:anywhere;">
     <label data-field="apiKey">API Key <input id="pe_apiKey"></label>
     <label data-field="apiEndpoint">API Endpoint <input id="pe_apiEndpoint"></label>
     <label data-field="model">Model <select id="pe_modelSelect" style="display:none"></select><input id="pe_modelInput"></label>

--- a/dist/popup/settings.html
+++ b/dist/popup/settings.html
@@ -12,6 +12,8 @@
       padding: 1rem;
       color: var(--qwen-text, #f5f5f7);
       width: 360px;
+      overflow-x: hidden;
+      overflow-wrap: anywhere;
     }
     .tabs { display: flex; gap: 0.5rem; margin-bottom: 0.5rem; }
     .tabs button {
@@ -29,7 +31,7 @@
     textarea { width: 100%; }
     .invalid { border-color: #ff4d4f; }
     .note { font-size: 0.8rem; opacity: 0.8; }
-    .provider-card { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); margin-bottom: 0.25rem; }
+    .provider-card { display: flex; align-items: center; gap: 0.5rem; padding: 0.25rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); margin-bottom: 0.25rem; overflow-wrap: anywhere; }
     .provider-card .drag-handle { cursor: move; }
     #addProviderOverlay { position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.6); display: none; align-items: center; justify-content: center; z-index: 1000; }
     #addProviderOverlay .modal { background: var(--qwen-bg, rgba(28,28,30,0.9)); padding: 1rem; border: 1px solid var(--qwen-border, rgba(255,255,255,0.2)); min-width: 260px; }
@@ -38,7 +40,7 @@
     #tmEntries, #tmStats {
       white-space: pre-wrap;
       word-break: break-word;
-      overflow-x: auto;
+      overflow-x: hidden;
     }
   </style>
 </head>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qwen-translator-extension",
-      "version": "1.41.0",
+      "version": "1.42.0",
       "hasInstallScript": true,
       "license": "AGPL-3.0-or-later",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qwen-translator-extension",
-  "version": "1.41.0",
+  "version": "1.42.0",
   "description": "Extension to translate web pages using Qwen-MT-Turbo model",
   "main": "index.js",
   "scripts": {

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -8,6 +8,8 @@ html[data-qwen-theme] {
   color: var(--qwen-text, #f5f5f7);
   margin: 0;
   padding: 1rem;
+  overflow-x: hidden;
+  overflow-wrap: anywhere;
 }
 
 [data-qwen-theme] body.home {
@@ -118,6 +120,7 @@ html[data-qwen-theme] {
   padding: 0.5rem;
   border: 1px solid var(--qwen-border, rgba(255,255,255,0.2));
   flex: 1 1 150px;
+  overflow-wrap: anywhere;
 }
 
 [data-qwen-theme] .provider-card:hover {
@@ -133,6 +136,7 @@ html[data-qwen-theme] {
   align-items: center;
   gap: 0.5rem;
   font-weight: 600;
+  overflow-wrap: anywhere;
 }
 
 [data-qwen-theme] .provider-avatar {
@@ -189,7 +193,7 @@ html[data-qwen-theme] {
 [data-qwen-theme] #tmStats {
   white-space: pre-wrap;
   word-break: break-word;
-  overflow-x: auto;
+  overflow-x: hidden;
   margin: 0;
   width: 100%;
 }


### PR DESCRIPTION
## Summary
- prevent popup overflow-x and wrap provider card text
- update popup HTML to hide horizontal scrollbars
- bump version to 1.42.0

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4ad97bf088323a8af5d69be6c694c