### PR TITLE
docs: add nightly rebase to merge queue

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,11 @@ Environment variables:
   - Ensure the branch is up to date and all required checks are green.
   - If the queue is stuck, check Bors logs and repository permissions.
 
+### Nightly Rebase
+- A scheduled workflow rebases all open PRs nightly and can be triggered manually.
+- PRs with merge conflicts are skipped and an automatic comment tags the author.
+- Contributors must resolve conflicts promptly so PRs can re-enter the merge queue.
+
 ## Definition of Done
 - Implement features using test-driven development (write failing tests first).
 - Update unit, integration, and end-to-end test automation.


### PR DESCRIPTION
## What
Add Nightly Rebase notes to merge queue guidelines.

## Why
Document scheduled workflow for rebasing PRs nightly to keep the queue current.

## How
- Architecture & design decisions (ADR ref if any)
- API/schema changes
- Feature flags & rollout plan

## Tests
- Unit: `npm test`
- Integration: N/A
- E2E/Contract: N/A
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: N/A (docs)
- Performance budgets: N/A

## Risks & Rollback
- Risks identified: minimal documentation risk
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a505c55d988323b4d57d8100281c03