### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+## What
+<short description of the change>
+
+## Why
+<business or technical reason for the change>
+
+## How
+- Architecture & design decisions (ADR ref if any)
+- API/schema changes
+- Feature flags & rollout plan
+
+## Tests
+- Unit:
+- Integration:
+- E2E/Contract:
+- Coverage: __%
+
+## Security & Perf
+- SAST/SCA/Secrets/IaC/Container: OK
+- Performance budgets: OK
+
+## Risks & Rollback
+- Risks identified:
+- Rollback plan:
+
+## Docs
+- AGENTS.md/ADR/diagrams updated
+
+## Checklist
+- [ ] Conventional Commit used
+- [ ] Changelog auto-updates correctly
+- [ ] Preview environment link(s) included

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Environment variables:
 - Commits follow [Conventional Commits](https://www.conventionalcommits.org/) in imperative present tense (`feat:`, `fix:`, `chore:`, `docs:` etc.).
 - Every functional change must include a `changeset` entry created via `npx changeset`.
 - PRs require a clear description, linked issue, test plan, and screenshots/GIFs for UI changes (PDF viewer, content script). Note any config changes.
+- PRs use `.github/PULL_REQUEST_TEMPLATE.md` for standardized sections.
 
 ## Release Workflow
 - Versioning and changelogs use [Changesets](https://github.com/changesets/changesets).


### PR DESCRIPTION
## What
Add standardized pull request template.

## Why
Ensures contributors provide consistent context and testing details.

## How
- Architecture & design decisions (ADR ref if any)
- API/schema changes
- Feature flags & rollout plan

## Tests
- Unit: `npm test`
- Integration: N/A
- E2E/Contract: N/A
- Coverage: N/A

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: `npm run secrets`, `npm audit`
- Performance budgets: `npm run size`

## Risks & Rollback
- Risks identified: minimal
- Rollback plan: revert commit

## Docs
- AGENTS.md/ADR/diagrams updated

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a5497b28a883238e212f68e6c981c8