### PR TITLE
docs: document nightly rebase policy

### DIFF
--- a/.changeset/nightly-rebase-docs.md
+++ b/.changeset/nightly-rebase-docs.md
@@ -2,5 +2,5 @@
 "qwen-translator-extension": none
 ---
 
-docs: document nightly rebase policy.
+docs: document nightly rebase policy
 


### PR DESCRIPTION
## What
- add changeset entry for nightly rebase docs

## Why
- document nightly rebase policy without triggering a release

## How
- changeset with `none` release type

## Tests
- `npm run lint`
- `npm run format`
- `npm test`
- `npm audit`
- `npm run secrets`
- `npm run size`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: `npm audit`, `npm run secrets`
- Performance budgets: `npm run size`

## Risks & Rollback
- Risks identified: incorrect documentation
- Rollback plan: revert commit and remove changeset file

## Docs
- AGENTS.md already mentions nightly rebase policy

## Checklist
- [x] Conventional Commit used
- [x] Changelog auto-updates correctly
- [ ] Preview environment link(s) included


------
https://chatgpt.com/codex/tasks/task_e_68a50b883b248323bfd7fdeed3b4f64e