### PR TITLE
fix: add product name link to popup header

### DIFF
--- a/.changeset/product-name-link.md
+++ b/.changeset/product-name-link.md
@@ -1,0 +1,4 @@
+---
+"translate-by-mikko": patch
+---
+Display product name link in popup header.

--- a/dist/popup.html
+++ b/dist/popup.html
@@ -9,7 +9,7 @@
 </head>
 <body class="popup">
   <header id="nav">
-    <span id="productName">TRANSLATE! by Mikko</span>
+    <a id="productName" href="https://github.com/homanp/Qwen-translator-extension" target="_blank" rel="noopener noreferrer">TRANSLATE! by Mikko</a>
     <button id="settingsBtn" class="icon-button" aria-label="Settings">
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <use href="icons/settings.svg#settings-icon"></use>

--- a/dist/styles/popup.css
+++ b/dist/styles/popup.css
@@ -246,6 +246,13 @@ html[data-qwen-theme] {
 
 [data-qwen-theme] #productName {
   font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+}
+
+[data-qwen-theme] #productName:hover,
+[data-qwen-theme] #productName:focus-visible {
+  text-decoration: underline;
 }
 
 [data-qwen-theme] #nav button {

--- a/src/popup.html
+++ b/src/popup.html
@@ -9,7 +9,7 @@
 </head>
 <body class="popup">
   <header id="nav">
-    <span id="productName">TRANSLATE! by Mikko</span>
+    <a id="productName" href="https://github.com/homanp/Qwen-translator-extension" target="_blank" rel="noopener noreferrer">TRANSLATE! by Mikko</a>
     <button id="settingsBtn" class="icon-button" aria-label="Settings">
       <svg viewBox="0 0 24 24" aria-hidden="true">
         <use href="icons/settings.svg#settings-icon"></use>

--- a/src/styles/popup.css
+++ b/src/styles/popup.css
@@ -246,6 +246,13 @@ html[data-qwen-theme] {
 
 [data-qwen-theme] #productName {
   font-weight: 600;
+  color: inherit;
+  text-decoration: none;
+}
+
+[data-qwen-theme] #productName:hover,
+[data-qwen-theme] #productName:focus-visible {
+  text-decoration: underline;
 }
 
 [data-qwen-theme] #nav button {

--- a/test/popup.test.js
+++ b/test/popup.test.js
@@ -5,18 +5,20 @@ global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 const { JSDOM } = require('jsdom');
 
-test('popup header displays product name', () => {
+test('popup header displays product name with link', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'src', 'popup.html'), 'utf8');
   const dom = new JSDOM(html);
-  const text = dom.window.document.getElementById('productName')?.textContent;
-  expect(text).toBe('TRANSLATE! by Mikko');
+  const link = dom.window.document.getElementById('productName');
+  expect(link?.textContent).toBe('TRANSLATE! by Mikko');
+  expect(link?.getAttribute('href')).toBe('https://github.com/homanp/Qwen-translator-extension');
 });
 
-test('built popup includes product name', () => {
+test('built popup includes product name with link', () => {
   const html = fs.readFileSync(path.join(__dirname, '..', 'dist', 'popup.html'), 'utf8');
   const dom = new JSDOM(html);
-  const text = dom.window.document.getElementById('productName')?.textContent;
-  expect(text).toBe('TRANSLATE! by Mikko');
+  const link = dom.window.document.getElementById('productName');
+  expect(link?.textContent).toBe('TRANSLATE! by Mikko');
+  expect(link?.getAttribute('href')).toBe('https://github.com/homanp/Qwen-translator-extension');
 });
 
 test('built popup css styles product name', () => {


### PR DESCRIPTION
## What
- show product name link in popup header for easy repo access

## Why
- product name was not visible, leaving empty space and no easy repo link

## How
- replace header span with anchor linking to GitHub and style for visibility
- add unit tests to assert link exists

## Tests
- `npm run format`
- `npm run lint`
- `npm test`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: minimal UI regression in popup header
- Rollback plan: revert commit

## Docs
- no doc updates needed

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a77eba27088323be35de23a68ed517