### PR TITLE
fix: limit auto-translate to active tab

### DIFF
--- a/.changeset/active-tab-autotranslate.md
+++ b/.changeset/active-tab-autotranslate.md
@@ -1,0 +1,4 @@
+---
+"translate-by-mikko": patch
+---
+Ensure auto-translate starts only for the active tab and stops all tabs when disabled.

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -884,7 +884,19 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
         });
         document.addEventListener('keydown', e => { if (e.key === 'Escape') removeSelectionBubble(); });
       }
-      if (cfg.autoTranslate) start();
+      if (cfg.autoTranslate) {
+        if (!document.hidden) {
+          start();
+        } else {
+          const onVisible = () => {
+            if (!document.hidden) {
+              document.removeEventListener('visibilitychange', onVisible);
+              start();
+            }
+          };
+          document.addEventListener('visibilitychange', onVisible);
+        }
+      }
     });
   }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -87,9 +87,10 @@
         chrome.storage?.sync?.set({ autoTranslate: msg.enabled });
         chrome.runtime.sendMessage({ action: 'set-config', config: { autoTranslate: msg.enabled } }, handleLastError());
         if (!msg.enabled) {
-          chrome.tabs?.query?.({ active: true, currentWindow: true }, tabs => {
-            const t = tabs && tabs[0];
-            if (t) chrome.tabs.sendMessage(t.id, { action: 'stop' }, handleLastError());
+          chrome.tabs?.query?.({}, tabs => {
+            (tabs || []).forEach(t => {
+              if (t.id) chrome.tabs.sendMessage(t.id, { action: 'stop' }, handleLastError());
+            });
           });
         }
         break;

--- a/test/autoTranslateVisibility.test.js
+++ b/test/autoTranslateVisibility.test.js
@@ -1,0 +1,37 @@
+// @jest-environment jsdom
+
+describe('content script auto-translate visibility', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    const sendMessage = jest.fn();
+    global.chrome = {
+      runtime: {
+        sendMessage,
+        getURL: () => 'chrome-extension://abc/',
+        onMessage: { addListener: () => {} },
+      },
+    };
+    window.qwenTranslateBatch = jest.fn(async () => ({ texts: [] }));
+    window.qwenLoadConfig = async () => ({ autoTranslate: true, debug: false });
+    window.qwenSetTokenBudget = jest.fn();
+    window.getComputedStyle = () => ({ visibility: 'visible', display: 'block' });
+    Element.prototype.getClientRects = () => [1];
+    Object.defineProperty(document, 'hidden', { value: true, configurable: true });
+    Object.defineProperty(document, 'visibilityState', { value: 'hidden', configurable: true });
+    Object.defineProperty(document, 'readyState', { value: 'complete', configurable: true });
+    document.body.innerHTML = '<p>hello</p>';
+  });
+
+  test('translation waits until tab is visible', async () => {
+    jest.useFakeTimers();
+    require('../src/contentScript.js');
+    await jest.runOnlyPendingTimersAsync();
+    expect(window.qwenTranslateBatch).not.toHaveBeenCalled();
+    Object.defineProperty(document, 'hidden', { value: false });
+    Object.defineProperty(document, 'visibilityState', { value: 'visible' });
+    document.dispatchEvent(new Event('visibilitychange'));
+    await jest.runOnlyPendingTimersAsync();
+    expect(window.qwenTranslateBatch).toHaveBeenCalled();
+    jest.useRealTimers();
+  });
+});

--- a/test/popupAutoTranslate.test.js
+++ b/test/popupAutoTranslate.test.js
@@ -1,0 +1,37 @@
+// @jest-environment jsdom
+
+describe('popup auto-translate toggle', () => {
+  let listener;
+  beforeEach(() => {
+    jest.resetModules();
+    document.body.innerHTML = '<iframe id="content"></iframe><button id="settingsBtn"></button>';
+    listener = undefined;
+    global.chrome = {
+      runtime: {
+        sendMessage: jest.fn(),
+        onMessage: { addListener: cb => { listener = cb; } },
+      },
+      storage: {
+        sync: {
+          get: jest.fn((defaults, cb) => cb({})),
+          set: jest.fn(),
+        },
+      },
+      tabs: {
+        query: jest.fn((query, cb) => cb([{ id: 1 }, { id: 2 }])),
+        sendMessage: jest.fn(),
+      },
+    };
+    require('../src/popup.js');
+  });
+
+  test('disabling auto-translate stops all tabs', () => {
+    chrome.tabs.sendMessage.mockClear();
+    listener({ action: 'home:auto-translate', enabled: false });
+    expect(chrome.storage.sync.set).toHaveBeenCalledWith({ autoTranslate: false });
+    expect(chrome.tabs.query).toHaveBeenCalledWith({}, expect.any(Function));
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledTimes(2);
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(1, { action: 'stop' }, expect.any(Function));
+    expect(chrome.tabs.sendMessage).toHaveBeenCalledWith(2, { action: 'stop' }, expect.any(Function));
+  });
+});


### PR DESCRIPTION
## What
- start auto-translate only when tab is visible
- stop translating in all tabs when auto-translate is disabled
- add coverage for auto-translate visibility and popup toggle

## Why
- prevent background tabs from translating automatically

## How
- gate start() behind visibility check
- broadcast stop message to every tab on disable

## Tests
- `npm test`
- `npm run lint`
- `npm run format`
- `npm audit`
- `npm run secrets`

## Security & Perf
- SAST/SCA/Secrets/IaC/Container: OK
- Performance budgets: OK

## Risks & Rollback
- Risks identified: none
- Rollback plan: revert commit

## Docs
- n/a

## Checklist
- [x] Conventional Commit used
- [ ] Changelog auto-updates correctly
- [ ] Preview environment link(s) included

------
https://chatgpt.com/codex/tasks/task_e_68a77df6a42083239f9c188c9d9ccc29