### PR TITLE
docs: surface WebMCP + correct provider tree + test count (MIK-3306)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,42 +4,37 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-**TRANSLATE!** is a browser extension for local-first translation across Chrome (MV3) and Firefox (MV2). The shipped paths are Chrome Built-in (native, Chrome 138+), OPUS-MT (stable downloaded local baseline), TranslateGemma (experimental accelerated local path), and optional cloud providers.
+**TRANSLATE!** is a browser extension for local-first translation across Chrome (MV3) and Firefox (MV2). The shipped paths are Chrome Built-in (native, Chrome 138+), OPUS-MT (stable downloaded local baseline), TranslateGemma (experimental accelerated local path via offscreen WebGPU/WebNN at `src/offscreen/translategemma.ts`), and optional cloud providers (DeepL, OpenAI, Anthropic, Google Cloud). NLLB-200 is in tree at `src/providers/nllb-200.ts` as an opt-in research path. The content script also exposes the extension as MCP tools (`translate_page`, `translate_selection`, `detect_language`) via `src/content/webmcp.ts` for in-page agent integrations.
 
-## Architecture (v2.0)
+## Architecture (v2.0+)
 
 ```
 src/
 ├── types/                 # TypeScript type definitions
-│   └── index.ts
-├── core/                  # Core translation infrastructure
-│   ├── throttle.ts        # Rate limiting with exponential backoff
-│   ├── webgpu-detector.ts # WebGPU detection and setup
-│   └── translation-router.ts # Legacy routing surface (not the canonical popup path)
-├── providers/             # Translation provider implementations
-│   ├── base-provider.ts   # Abstract base class
-│   └── opus-mt-local.ts   # Helsinki-NLP OPUS-MT via Transformers.js
+├── core/                  # Core translation infrastructure (~25 modules: throttle, circuit-breaker, glossary, language-detector, prediction-engine, translation-cache, translation-router, webgpu-detector, ...)
+├── providers/             # 7 translation provider implementations + base abstract
+│   ├── base-provider.ts
+│   ├── opus-mt-local.ts   # Helsinki-NLP OPUS-MT via Transformers.js
+│   ├── chrome-translator.ts # Chrome Built-in (Chrome 138+)
+│   ├── deepl.ts
+│   ├── openai.ts
+│   ├── anthropic.ts
+│   ├── google-cloud.ts
+│   ├── nllb-200.ts        # opt-in NLLB research path (not exported from index.ts)
+│   └── cloud-provider.ts  # shared cloud-provider helpers
+├── offscreen/
+│   └── translategemma.ts  # experimental WebGPU/WebNN local accelerated path
+├── content/
+│   ├── index.ts           # main content script (DOM walking, MutationObserver)
+│   └── webmcp.ts          # MCP tool surface for in-page agent integrations (~553 LOC, e2e harness in e2e/webmcp-harness.html)
 ├── popup/                 # Solid.js popup UI
-│   ├── App.tsx
-│   ├── index.tsx
-│   ├── index.html
-│   ├── styles/popup.css
-│   └── components/
-│       ├── ProviderStatus.tsx
-│       ├── LanguageSelector.tsx
-│       ├── StrategySelector.tsx
-│       ├── UsageBar.tsx
-│       └── CostMonitor.tsx
 ├── options/               # Settings page
-│   └── index.html
-├── background/            # Background scripts
-│   ├── service-worker.ts  # Chrome MV3 service worker
-│   └── background-firefox.ts # Firefox MV2 background page
-├── content/               # Content script
-│   └── index.ts
-├── manifest.json          # Chrome manifest (MV3)
-└── manifest.firefox.json  # Firefox manifest (MV2)
+├── background/            # MV3 service worker + Firefox MV2 background page
+├── manifest.json          # Chrome (MV3)
+└── manifest.firefox.json  # Firefox (MV2)
 ```
+
+The src/ tree is far richer than this skeleton; treat the listing above as the load-bearing surfaces for agent onboarding. For a full file inventory run `fd -t f . src/` rather than asking the doc.
 
 ## Canonical shipped runtime paths
 
@@ -62,6 +57,7 @@ src/
 - Treat `chrome-builtin` and `opus-mt` as the canonical shipped user-facing translation paths.
 - Treat `translategemma` as experimental.
 - Do not treat `translation-router`, `localModel`, `llama.cpp`, or `wllama` surfaces as the canonical shipped runtime unless a task explicitly targets those legacy/experimental paths.
+- The content-script WebMCP surface in `src/content/webmcp.ts` is canonical for in-page MCP-aware agent integrations (Claude.ai, agent harnesses). Do not assume agents only reach the extension via the popup.
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code when working with this repository.
 
 ## Project Overview
 
-**TRANSLATE!** is a browser extension for local-first translation across Chrome (MV3) and Firefox (MV2). The shipped paths are Chrome Built-in (native, Chrome 138+), OPUS-MT (stable downloaded local baseline), TranslateGemma (experimental accelerated local path via offscreen WebGPU/WebNN at `src/offscreen/translategemma.ts`), and optional cloud providers (DeepL, OpenAI, Anthropic, Google Cloud). NLLB-200 is in tree at `src/providers/nllb-200.ts` as an opt-in research path. The content script also exposes the extension as MCP tools (`translate_page`, `translate_selection`, `detect_language`) via `src/content/webmcp.ts` for in-page agent integrations.
+**TRANSLATE!** is a browser extension for local-first translation across Chrome (MV3) and Firefox (MV2). The shipped paths are Chrome Built-in (native, Chrome 138+), OPUS-MT (stable downloaded local baseline), TranslateGemma (experimental accelerated local path via offscreen WebGPU/WebNN at `src/offscreen/translategemma.ts`), and optional cloud providers (DeepL, OpenAI, Anthropic, Google Cloud). NLLB-200 is in tree at `src/providers/nllb-200.ts` as an opt-in research path. PR #509 shipped the content-script WebMCP surface, which exposes the extension as MCP tools (`translate_page`, `translate_selection`, `detect_language`) via `src/content/webmcp.ts` for in-page agent integrations.
 
 ## Architecture (v2.0+)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Built-in browser translation (Chrome, Safari, Firefox) works well for many pages
 
 - **Full-page translation** -- translates visible text on a page, including dynamically loaded content and iframes. A MutationObserver watches for DOM changes so content added after page load is caught.
 - **PDF translation** -- built-in PDF viewer with layout-preserving translation. Supports provider document APIs (Google Cloud, DeepL) and a local WASM pipeline. Save translated PDFs.
-- **7 shipping translation providers** -- Chrome Built-in, OPUS-MT, TranslateGemma (experimental), DeepL, OpenAI, Anthropic, and Google Cloud. Switch on the fly between the available native, local, and cloud paths.
+- **7 shipping translation providers** -- Chrome Built-in, OPUS-MT, TranslateGemma (experimental, offscreen WebGPU/WebNN path in `src/offscreen/translategemma.ts`), DeepL, OpenAI, Anthropic, and Google Cloud. NLLB-200 (`src/providers/nllb-200.ts`) is in tree as an opt-in research path. Switch on the fly between the available native, local, and cloud paths.
+- **WebMCP integration** -- the content script exposes the extension as Model Context Protocol tools (`translate_page`, `translate_selection`, `detect_language`) to any in-page MCP-aware agent via `src/content/webmcp.ts`. Compatible MCP clients (Claude.ai, agent harnesses) can drive translation directly without going through the popup. End-to-end harness lives in `e2e/webmcp-harness.html` + `e2e/webmcp-integration.spec.ts`.
 - **Failover and load balancing** -- if your primary provider hits a rate limit or fails, requests automatically route to the next provider in your chain.
 - **Smart batching and caching** -- identical strings translated once and reused. Hidden elements skipped. Session cache minimizes repeat API calls.
 - **Auto-translate** -- optionally translate pages on load.
@@ -53,7 +54,7 @@ If built-in translation works reliably for your languages and pages, you probabl
 
 | Metric           | Value                                                              |
 | ---------------- | ------------------------------------------------------------------ |
-| Unit tests       | 5k+ Vitest tests across 150+ files                                 |
+| Unit tests       | 6.5k+ Vitest cases across 160+ files                               |
 | Coverage gates   | Enforced in CI via `npm run test:coverage`                         |
 | Contract tests   | Provider interface conformance checks                              |
 | Mutation testing | Stryker configured for core + providers                            |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/MikkoParkkola/translate-browser-extension/actions/workflows/ci.yml/badge.svg)](https://github.com/MikkoParkkola/translate-browser-extension/actions/workflows/ci.yml)
 [![CodeQL](https://github.com/MikkoParkkola/translate-browser-extension/actions/workflows/codeql.yml/badge.svg)](https://github.com/MikkoParkkola/translate-browser-extension/actions/workflows/codeql.yml)
-![Tests](https://img.shields.io/badge/tests-5k%2B%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-6.5k%2B%20passed-brightgreen)
 ![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue?logo=typescript&logoColor=white)
 ![License](https://img.shields.io/github/license/MikkoParkkola/translate-browser-extension)
 ![Chrome](https://img.shields.io/badge/Chrome-116%2B-brightgreen?logo=googlechrome&logoColor=white)
@@ -32,7 +32,7 @@ Built-in browser translation (Chrome, Safari, Firefox) works well for many pages
 - **Full-page translation** -- translates visible text on a page, including dynamically loaded content and iframes. A MutationObserver watches for DOM changes so content added after page load is caught.
 - **PDF translation** -- built-in PDF viewer with layout-preserving translation. Supports provider document APIs (Google Cloud, DeepL) and a local WASM pipeline. Save translated PDFs.
 - **7 shipping translation providers** -- Chrome Built-in, OPUS-MT, TranslateGemma (experimental, offscreen WebGPU/WebNN path in `src/offscreen/translategemma.ts`), DeepL, OpenAI, Anthropic, and Google Cloud. NLLB-200 (`src/providers/nllb-200.ts`) is in tree as an opt-in research path. Switch on the fly between the available native, local, and cloud paths.
-- **WebMCP integration** -- the content script exposes the extension as Model Context Protocol tools (`translate_page`, `translate_selection`, `detect_language`) to any in-page MCP-aware agent via `src/content/webmcp.ts`. Compatible MCP clients (Claude.ai, agent harnesses) can drive translation directly without going through the popup. End-to-end harness lives in `e2e/webmcp-harness.html` + `e2e/webmcp-integration.spec.ts`.
+- **WebMCP integration** -- shipped in PR #509, the content script exposes the extension as Model Context Protocol tools (`translate_page`, `translate_selection`, `detect_language`) to any in-page MCP-aware agent via `src/content/webmcp.ts`. Compatible MCP clients (Claude.ai, agent harnesses) can drive translation directly without going through the popup. End-to-end harness lives in `e2e/webmcp-harness.html` + `e2e/webmcp-integration.spec.ts`.
 - **Failover and load balancing** -- if your primary provider hits a rate limit or fails, requests automatically route to the next provider in your chain.
 - **Smart batching and caching** -- identical strings translated once and reused. Hidden elements skipped. Session cache minimizes repeat API calls.
 - **Auto-translate** -- optionally translate pages on load.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,6 +8,7 @@ TRANSLATE! is a multi-provider browser translation extension that ships on Chrom
 
 - **Background Service Worker** - Provider routing, rate limiting, caching, message hub
 - **Content Script** - DOM scanning, text extraction, translation injection, MutationObserver
+- **WebMCP Content Surface** - PR #509 added in-page MCP tool registration from the content script via `src/content/webmcp.ts`
 - **Popup UI** - Translation controls, language selection, provider status
 - **Options UI** - Provider configuration, API keys, settings management
 
@@ -26,6 +27,7 @@ TRANSLATE! is a multi-provider browser translation extension that ships on Chrom
 #### Shipping status
 - **Stable**: `chrome-builtin`, `opus-mt`, and configured cloud providers
 - **Experimental**: `translategemma`
+- **Agent integration**: WebMCP tools `translate_page`, `translate_selection`, and `detect_language` ship from `src/content/webmcp.ts` with coverage in `src/content/webmcp.test.ts` and `e2e/webmcp-integration.spec.ts`.
 - Legacy `localModel` / `llama.cpp` / `wllama` surfaces were removed after they were confirmed to be quarantined and unused by shipped entry points.
 
 ### Provider Routing System
@@ -44,6 +46,17 @@ The extension routes translation requests through the browser-appropriate backgr
 3. **Route** - Send to primary provider, fail over if rate-limited or unavailable
 4. **Cache** - Store results for session, reuse across matching nodes
 5. **Inject** - Replace original text preserving whitespace and structure
+
+### WebMCP Agent Pipeline
+
+PR #509 also made the content script an MCP-aware integration point for pages that expose `navigator.modelContext`.
+
+1. **Register** - `src/content/webmcp.ts` registers `translate_page`, `translate_selection`, and `detect_language` with MCP annotations. Selection translation and language detection are read-only; page translation is not read-only because it updates page content.
+2. **Invoke** - an in-page MCP-aware agent calls one of those tools with source/target language, strategy, and optional provider hints.
+3. **Dispatch** - the content script reuses the same translation handlers as user-driven popup/content actions.
+4. **Return** - the tool returns a text response or compact page summary without exposing API keys or background internals.
+
+The WebMCP e2e harness lives in `e2e/webmcp-harness.html` and `e2e/webmcp-integration.spec.ts`.
 
 ### Offline Integration
 
@@ -102,6 +115,8 @@ interface ITranslationProvider {
 ```
 
 Providers are registered at runtime, no core code changes required.
+
+Agent-facing integrations should use the WebMCP surface instead of inventing a second page-automation API. Additions to that surface belong in `src/content/webmcp.ts` and should include unit coverage plus the e2e harness path from PR #509.
 
 ## Full Details
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,5 +1,13 @@
 # TranslateGemma-4B Quantization Documentation Index
 
+## Current Runtime Cross-Reference
+
+This index is for the TranslateGemma quantization planning set, not the full extension architecture. For the current shipped extension surface, cross-check the live architecture docs before treating any quantization plan as implementation truth.
+
+- **WebMCP shipped in PR #509**: `src/content/webmcp.ts` exposes `translate_page`, `translate_selection`, and `detect_language` as in-page MCP tools for agent integrations. Coverage lives in `src/content/webmcp.test.ts`, `e2e/webmcp-integration.spec.ts`, and `e2e/webmcp-harness.html`.
+- **TranslateGemma status**: experimental offscreen WebGPU/WebNN path at `src/offscreen/translategemma.ts`; the quantization docs below remain planning material until their follow-up tracker verifies the current model-format and deployment assumptions.
+- **NLLB-200 status**: `src/providers/nllb-200.ts` exists as an opt-in research path and is not the replacement for TranslateGemma in shipped provider docs.
+
 ## Quick Navigation
 
 ### For Decision Makers (5-10 min)


### PR DESCRIPTION
## Summary

Portfolio doc-audit 2026-05-02 surfaced 3 doc-drift items in translate-browser-extension:

1. WebMCP integration shipped in PR #509 (553 LOC src/content/webmcp.ts plus tests plus e2e harness) but no doc mentioned it. README, CLAUDE.md, ARCHITECTURE.md, INDEX.md all still described a pre-WebMCP popup-content-background pipeline.
2. CLAUDE.md src/ tree showed only opus-mt-local under providers and 3 modules under core. Reality: 8 provider files, approximately 25 core modules.
3. README claimed "5k+ Vitest tests across 150+ files" — live count is 6515 test declarations across 160 test files.

## Changes

- README.md: WebMCP feature bullet (3 MCP tool names plus e2e harness location), TranslateGemma disambiguated as offscreen path at src/offscreen/translategemma.ts, NLLB-200 noted as opt-in research path, test count updated to 6.5k+ across 160+ files.
- CLAUDE.md: Project Overview mentions WebMCP plus NLLB-200 plus full cloud-provider list. src/ skeleton rewritten to match reality with an explicit fallback note for full inventory. Guidance gains a canonical-WebMCP-surface point.

No code change. Test counts verified live via rg-based count of test declarations and expect() calls.

## Test plan

- [x] Test counts verified live: rg-based count returned 6515 declarations across 160 test files
- [x] WebMCP surface verified: webmcp.ts at 553 LOC plus companion test plus e2e integration spec plus harness html all exist
- [x] Provider count verified: 8 files including anthropic, base-provider, chrome-translator, cloud-provider, deepl, google-cloud, nllb-200, openai, opus-mt-local
- [ ] Manual smoke test of WebMCP harness (deferred to follow-up; this PR is doc-only)

Source: portfolio doc-audit appendix tier-3, translate-browser-extension section; MIK-3306.

Generated with Claude Code (https://claude.com/claude-code)
