### PR TITLE
ci: add GitHub Actions Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "UTC"


### PR DESCRIPTION
MIK-2922 Phase 4 Dependabot follow-up.

What changed:
- Adds Dependabot v2 config for `package-ecosystem: "github-actions"` at `/`.
- Uses the existing portfolio schedule pattern: weekly Monday 06:00 UTC.

Validation:
- YAML parse passed with Ruby Psych.
- `git diff --check` passed.
- Focused review found no blocking correctness/security issues.

Scope honesty: this only enables GitHub Actions update PRs for review; it does not SHA-pin existing workflow actions or close MIK-2922.
