### PR TITLE
Evaluate Transformers.js v4 WebGPU probe

### DIFF
--- a/docs/translate-webgpu-handoff.md
+++ b/docs/translate-webgpu-handoff.md
@@ -1,51 +1,81 @@
-# OPUS-MT WebGPU Spike
+# Transformers.js v4 WebGPU Spike
 
-## Scope
+GitHub issue: [#508](https://github.com/MikkoParkkola/translate-browser-extension/issues/508)
 
-- Upgrade `@huggingface/transformers` to the v4 runtime.
-- Keep OPUS-MT on the current safe default: `wasm + q8`, but retry `wasm + fp32` after q8 load failures to isolate quantization-only regressions.
-- Allow explicit WebGPU probing behind `VITE_OPUS_MT_WEBGPU_PROBE=true`.
+## Current Implementation
 
-## What this spike changes
+- `@huggingface/transformers` is upgraded to the v4 runtime (`^4.2.0`).
+- OPUS-MT production defaults remain `wasm + q8`.
+- `VITE_OPUS_MT_WEBGPU_PROBE=true` enables an explicit OPUS-MT probe path:
+  1. try `webgpu + q8` when browser WebGPU is detected
+  2. fall back to `wasm + q8` if the probe load fails
+- Both Chrome offscreen and Firefox background paths enable `env.useWasmCache = true`.
+- Extension packaging copies the ONNX Runtime `ort-wasm*` loader/runtime files from `onnxruntime-web/dist`, which v4 imports dynamically at runtime.
+- `npm run spike:transformers-v4` runs a local measurement harness for model load time, inference time, estimated output tokens/sec, memory delta, and offline cache checks.
 
-- Chrome offscreen OPUS-MT path uses the same runtime policy as Firefox.
-- Firefox background OPUS-MT path now also defaults to `wasm + q8`.
-- Shared OPUS-MT runtime selection keeps q8 fixed, only opts into WebGPU when the probe flag is enabled and support is detected, and now retries `wasm + fp32` after q8 load failures for diagnosis.
-- Transformers.js v4 enables `env.useWasmCache = true` so compiled WASM artifacts can be reused between loads.
-- The Vite build now patches the published `transformers.web.js` bundle so a failed browser-side ONNX session load does not poison later fallback attempts in the same extension context.
-- Extension packaging now copies the ONNX Runtime `ort-wasm*` loader/runtime files from `onnxruntime-web/dist`, which v4 imports dynamically at runtime.
-- Probe builds now log OPUS-MT input/output sentence counts and head/tail excerpts so two-sentence truncation is easier to reproduce and compare across runtimes.
-- Probe builds now route multi-sentence OPUS-MT inputs through sentence-level inference calls, which keeps the WebGPU probe active while avoiding the reproduced English→Finnish truncation/collapse pattern.
+## Measurement Harness
 
-## Probe contract
+Warm/cache smoke:
 
-Set `VITE_OPUS_MT_WEBGPU_PROBE=true` only for manual evaluation builds.
+```bash
+npm run spike:transformers-v4 -- --device=cpu
+```
 
-- `false` or unset: force `wasm + q8`
-- `true`: try `webgpu + q8` when supported, otherwise stay on `wasm + q8`
+Offline follow-up after one successful warm run:
 
-## Manual GO / KILL checklist
+```bash
+npm run spike:transformers-v4 -- --device=cpu --offline
+```
 
-GO only if all of the following hold for a representative pair such as `en ↔ fi`:
+WebGPU probe:
 
-1. output is not degenerate or repetitive
-2. first load completes within the existing OPUS-MT timeout budget
-3. warm runs remain stable across repeated translations
+```bash
+npm run spike:transformers-v4 -- --device=webgpu
+```
 
-KILL the WebGPU path if output regresses, model load becomes flaky, or the runtime still falls back unpredictably.
+The Node runtime used by the local CLI does not expose `navigator.gpu`, and Transformers.js v4 maps the local Node fallback to `cpu` rather than browser `wasm`. Use the CLI for cache/quality smoke checks; use the production extension probe flag for real browser WebGPU/WASM validation:
 
-## Current browser findings
+```bash
+VITE_OPUS_MT_WEBGPU_PROBE=true npm run build
+```
 
-Observed on this macOS machine in Chromium with a real extension build:
+Then load `dist/` unpacked and translate a small `en -> de` or `en -> fi` sample.
 
-- `checkWebGPU` reports `supported=true` and `fp16=true`
-- probe-enabled build (`VITE_OPUS_MT_WEBGPU_PROBE=true`) now loads and translates after the packaging fix
-- first probe translation took about 79s cold, and a same-session offline follow-up completed in about 0.5s
-- before the sentence-level probe guard, the probe output quality was not trustworthy enough to ship by default: a two-sentence `en -> fi` input returned only one translated sentence, and a four-sentence sample collapsed into one merged sentence
-- the default v4 `wasm + q8` path is currently not safe on this machine: ONNX Runtime session creation fails with `Missing required scale: model.shared.weight_merged_0_scale`
-- the first retry investigation found an upstream Transformers.js v4 web-bundle bug: after one failed ONNX session load, `webInitChain` stays rejected and later fallback attempts inherit the same failure instead of starting a fresh load
-- after patching that published web bundle during the Vite build, the same Chrome offscreen probe succeeded via the intended `wasm + fp32` fallback (`Hello world. I like apples. This is a test.` → `Hallo Welt. Ich mag Äpfel. Dies ist ein Test.`)
-- a normal extension-page `type: 'translate'` request now also succeeds on the same build in about 50s cold, which confirms the workaround is active on the user-facing Chrome background/offscreen path as well
-- with the new sentence-level probe guard in place, the same live options-page path now returns full multi-sentence outputs for the previously bad `en -> fi` cases (`First sentence. Second sentence.` → `Ensimmäinen lause. Toinen lause.` and a four-sentence sample returning four Finnish sentences), while `en -> de` still returns a full three-sentence result on the probe build
+## GO / KILL Criteria
 
-Current recommendation: keep this PR draft until a broader probe matrix is rerun, but the previously reproduced English→Finnish multi-sentence WebGPU failure is now mitigated well enough to keep evaluating the v4 probe path instead of treating that specific repro as an active blocker.
+GO only if all of these hold for representative `en <-> fi` and `en <-> de` samples:
+
+- WebGPU inference loads without corrupting the extension runtime.
+- Single-sentence translation completes in less than 2 seconds on a warm model.
+- Offline follow-up works after the first model download.
+- Output is not degenerate, repetitive, or truncated.
+- WASM fallback still succeeds when WebGPU load fails.
+
+KILL or keep probe-only if any of these occur:
+
+- WebGPU output regresses relative to the current WASM path.
+- Model load is flaky across browser restarts.
+- Browser memory usage is too high for typical extension users.
+- Firefox or Safari requires flags or implementation-specific behavior that cannot be made ergonomic.
+
+## Open Browser Matrix
+
+The repeatable harness and probe flag are now in place. Before shipping WebGPU as a default path, run and record:
+
+| Browser | Required check |
+| --- | --- |
+| Chrome/Edge | Probe build, warm/cold load, offline follow-up, quality sample |
+| Firefox | Probe build with WebGPU flag state documented |
+| Safari | Probe build or documented unsupported status |
+
+Until that matrix is recorded, OPUS-MT WebGPU remains experimental and disabled by default.
+
+## Local Node Smoke Result
+
+Run on 2026-05-12 with `Xenova/opus-mt-en-de`, `device=cpu`, `dtype=q8`, and input `Hello world. I like apples.`
+
+| Mode | Result |
+| --- | --- |
+| Cold online | load `37422ms`, inference `116ms`, estimated `60.49 tok/s`, output `Hallo Welt. Ich mag Äpfel.` |
+| Offline after cache warm | load `470ms`, inference `136ms`, estimated `51.54 tok/s`, same output |
+| WebGPU from Node | blocked because this Node runtime exposes no `navigator.gpu` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@huggingface/transformers": "^3.8.1",
+        "@huggingface/transformers": "^4.2.0",
         "franc-min": "^6.2.0",
         "mupdf": "^1.26.4",
         "pdfjs-dist": "^5.4.54",
@@ -1453,16 +1453,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@huggingface/transformers": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-3.8.1.tgz",
-      "integrity": "sha512-tsTk4zVjImqdqjS8/AOZg2yNLd1z9S5v+7oUPpXaasDRwEDhB+xnglK1k5cad26lL5/ZIaeREgWWy0bs9y9pPA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@huggingface/jinja": "^0.5.3",
-        "onnxruntime-node": "1.21.0",
-        "onnxruntime-web": "1.22.0-dev.20250409-89f8206ba4",
-        "sharp": "^0.34.1"
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
       }
     },
     "node_modules/@humanfs/core": {
@@ -2513,18 +2520,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/@isaacs/fs-minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
-      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
-      "license": "ISC",
-      "dependencies": {
-        "minipass": "^7.0.4"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
@@ -3047,9 +3042,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
@@ -3075,9 +3070,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
@@ -3093,9 +3088,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -4213,6 +4208,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
@@ -5155,15 +5159,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/chownr": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/chrome-trace-event": {
@@ -6609,9 +6604,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -8882,21 +8877,10 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
       "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/minizlib": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-      "license": "MIT",
-      "dependencies": {
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
       }
     },
     "node_modules/mkdirp": {
@@ -9342,15 +9326,15 @@
       }
     },
     "node_modules/onnxruntime-common": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz",
-      "integrity": "sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
       "license": "MIT"
     },
     "node_modules/onnxruntime-node": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz",
-      "integrity": "sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==",
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
       "hasInstallScript": true,
       "license": "MIT",
       "os": [
@@ -9359,29 +9343,29 @@
         "linux"
       ],
       "dependencies": {
+        "adm-zip": "^0.5.16",
         "global-agent": "^3.0.0",
-        "onnxruntime-common": "1.21.0",
-        "tar": "^7.0.1"
+        "onnxruntime-common": "1.24.3"
       }
     },
     "node_modules/onnxruntime-web": {
-      "version": "1.22.0-dev.20250409-89f8206ba4",
-      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.22.0-dev.20250409-89f8206ba4.tgz",
-      "integrity": "sha512-0uS76OPgH0hWCPrFKlL8kYVV7ckM7t/36HfbgoFw6Nd0CZVVbQC4PkrR8mBX8LtNUFZO25IQBqV2Hx2ho3FlbQ==",
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
       "license": "MIT",
       "dependencies": {
         "flatbuffers": "^25.1.24",
         "guid-typescript": "^1.0.9",
         "long": "^5.2.3",
-        "onnxruntime-common": "1.22.0-dev.20250409-89f8206ba4",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
         "platform": "^1.3.6",
         "protobufjs": "^7.2.4"
       }
     },
     "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
-      "version": "1.22.0-dev.20250409-89f8206ba4",
-      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.22.0-dev.20250409-89f8206ba4.tgz",
-      "integrity": "sha512-vDJMkfCfb0b1A836rgHj+ORuZf4B4+cc2bASQtpeoJLueuFc5DuYwjIZUBrSvx/fO5IrLjLz+oTrB3pcGlhovQ==",
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
       "license": "MIT"
     },
     "node_modules/opencollective-postinstall": {
@@ -9972,22 +9956,22 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
-      "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
+      "version": "7.5.7",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.7.tgz",
+      "integrity": "sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/codegen": "^2.0.5",
         "@protobufjs/eventemitter": "^1.1.0",
         "@protobufjs/fetch": "^1.1.0",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/inquire": "^1.1.1",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
         "long": "^5.0.0"
       },
@@ -11235,22 +11219,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/fs-minipass": "^4.0.0",
-        "chownr": "^3.0.0",
-        "minipass": "^7.1.2",
-        "minizlib": "^3.1.0",
-        "yallist": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tar-stream": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
@@ -11262,15 +11230,6 @@
         "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/tar/node_modules/yallist": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/teex": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "secrets": "gitleaks detect --no-git",
     "serve": "http-server dist -p 8080",
     "serve:e2e": "http-server . -p 8080",
+    "spike:transformers-v4": "node scripts/transformers-v4-webgpu-spike.mjs",
     "size": "npm run build && size-limit",
     "size:analyze": "npm run build && webpack-bundle-analyzer dist --port 8888",
     "size:report": "npm run build && size-limit --json > size-report.json",
@@ -118,13 +119,14 @@
     "webpack-bundle-analyzer": "^4.10.0"
   },
   "dependencies": {
-    "@huggingface/transformers": "^3.8.1",
+    "@huggingface/transformers": "^4.2.0",
     "franc-min": "^6.2.0",
     "mupdf": "^1.26.4",
     "pdfjs-dist": "^5.4.54",
     "tesseract.js": "^7.0.0"
   },
   "overrides": {
+    "fast-uri": "^3.1.2",
     "protobufjs": "^7.5.5"
   }
 }

--- a/scripts/transformers-v4-webgpu-spike.mjs
+++ b/scripts/transformers-v4-webgpu-spike.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+import { mkdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_OPTIONS = Object.freeze({
+  model: 'Xenova/opus-mt-en-de',
+  device: 'auto',
+  dtype: 'q8',
+  text: 'Hello world. I like apples. This is a local translation smoke test.',
+  cacheDir: '.cache/transformers-v4-spike',
+  offline: false,
+  maxLength: 512,
+});
+
+const SUPPORTED_DEVICES = new Set(['auto', 'webgpu', 'wasm', 'cpu']);
+
+export function parseSpikeArgs(argv) {
+  const options = { ...DEFAULT_OPTIONS };
+
+  for (const arg of argv) {
+    if (arg === '--offline') {
+      options.offline = true;
+      continue;
+    }
+
+    const [key, ...valueParts] = arg.replace(/^--/, '').split('=');
+    const value = valueParts.join('=');
+
+    switch (key) {
+      case 'model':
+      case 'device':
+      case 'dtype':
+      case 'text':
+      case 'cache-dir':
+        if (!value) {
+          throw new Error(`Missing value for --${key}`);
+        }
+        options[key === 'cache-dir' ? 'cacheDir' : key] = value;
+        break;
+      case 'max-length': {
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          throw new Error('--max-length must be a positive integer');
+        }
+        options.maxLength = parsed;
+        break;
+      }
+      default:
+        throw new Error(`Unknown option: --${key}`);
+    }
+  }
+
+  if (!SUPPORTED_DEVICES.has(options.device)) {
+    throw new Error(`Unsupported device "${options.device}". Use auto, webgpu, wasm, or cpu.`);
+  }
+
+  return options;
+}
+
+export function resolveSpikeDevice(requestedDevice, hasWebGpu, isNodeRuntime = true) {
+  if (requestedDevice === 'auto') {
+    return hasWebGpu ? 'webgpu' : (isNodeRuntime ? 'cpu' : 'wasm');
+  }
+
+  if (requestedDevice === 'wasm' && isNodeRuntime) {
+    return 'cpu';
+  }
+
+  return requestedDevice;
+}
+
+export function estimateTokenCount(text) {
+  if (!text) return 0;
+  return Math.max(1, Math.ceil(String(text).trim().length / 4));
+}
+
+export function calculateMemoryDelta(before, after) {
+  if (!before || !after) return null;
+  return {
+    rssBytes: after.rss - before.rss,
+    heapUsedBytes: after.heapUsed - before.heapUsed,
+    externalBytes: after.external - before.external,
+  };
+}
+
+export function summarizeInferenceMetrics({ loadMs, inferenceMs, outputText, memoryBefore, memoryAfter }) {
+  const estimatedOutputTokens = estimateTokenCount(outputText);
+  const inferenceSeconds = Math.max(inferenceMs / 1000, 0.001);
+
+  return {
+    loadMs: Math.round(loadMs),
+    inferenceMs: Math.round(inferenceMs),
+    estimatedOutputTokens,
+    estimatedTokensPerSecond: Number((estimatedOutputTokens / inferenceSeconds).toFixed(2)),
+    memoryDelta: calculateMemoryDelta(memoryBefore, memoryAfter),
+  };
+}
+
+export function buildTransformersEnvSettings(options) {
+  const offline = options.offline === true;
+
+  return {
+    allowRemoteModels: !offline,
+    allowLocalModels: offline,
+    useBrowserCache: false,
+    useFSCache: true,
+    useWasmCache: true,
+    cacheDir: resolve(options.cacheDir || DEFAULT_OPTIONS.cacheDir),
+  };
+}
+
+function hasNavigatorWebGpu() {
+  return typeof globalThis.navigator !== 'undefined' && Boolean(globalThis.navigator.gpu);
+}
+
+function isNodeRuntime() {
+  return typeof process !== 'undefined' && Boolean(process.versions?.node);
+}
+
+function memorySnapshot() {
+  return typeof process.memoryUsage === 'function' ? process.memoryUsage() : null;
+}
+
+function normalizePipelineOutput(result) {
+  if (!Array.isArray(result) || result.length === 0) return '';
+  const first = result[0];
+  return typeof first?.translation_text === 'string' ? first.translation_text : '';
+}
+
+export async function runSpike(rawOptions = {}) {
+  const options = { ...DEFAULT_OPTIONS, ...rawOptions };
+  const hasWebGpu = hasNavigatorWebGpu();
+  const device = resolveSpikeDevice(options.device, hasWebGpu, isNodeRuntime());
+
+  if (device === 'webgpu' && !hasWebGpu) {
+    throw new Error(
+      'WebGPU was requested, but navigator.gpu is not available in this runtime. ' +
+      'Run this in a WebGPU-capable browser context, or use --device=cpu for a cache/quality smoke test.'
+    );
+  }
+
+  const cacheDir = resolve(options.cacheDir);
+  await mkdir(cacheDir, { recursive: true });
+
+  const { env, pipeline } = await import('@huggingface/transformers');
+  const envSettings = buildTransformersEnvSettings(options);
+  env.allowRemoteModels = envSettings.allowRemoteModels;
+  env.allowLocalModels = envSettings.allowLocalModels;
+  env.useBrowserCache = envSettings.useBrowserCache;
+  env.useFSCache = envSettings.useFSCache;
+  env.cacheDir = envSettings.cacheDir;
+  env.useWasmCache = envSettings.useWasmCache;
+
+  const progressEvents = [];
+  const memoryBefore = memorySnapshot();
+  const loadStart = performance.now();
+  const translator = await pipeline('translation', options.model, {
+    device,
+    dtype: options.dtype,
+    local_files_only: options.offline,
+    progress_callback: (progress) => {
+      progressEvents.push({
+        status: progress?.status,
+        file: progress?.file,
+        progress: progress?.progress,
+      });
+    },
+  });
+  const loadMs = performance.now() - loadStart;
+
+  const inferenceStart = performance.now();
+  const result = await translator(options.text, { max_length: options.maxLength });
+  const inferenceMs = performance.now() - inferenceStart;
+  const outputText = normalizePipelineOutput(result);
+  const memoryAfter = memorySnapshot();
+
+  return {
+    transformersVersion: env.version,
+    model: options.model,
+    device,
+    dtype: options.dtype,
+    offline: options.offline,
+    inputText: options.text,
+    outputText,
+    progressEventCount: progressEvents.length,
+    ...summarizeInferenceMetrics({
+      loadMs,
+      inferenceMs,
+      outputText,
+      memoryBefore,
+      memoryAfter,
+    }),
+  };
+}
+
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  runSpike(parseSpikeArgs(process.argv.slice(2)))
+    .then((result) => {
+      console.log(JSON.stringify(result, null, 2));
+    })
+    .catch((error) => {
+      console.error(JSON.stringify({
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      }, null, 2));
+      process.exitCode = 1;
+    });
+}

--- a/src/background/background-firefox.ts
+++ b/src/background/background-firefox.ts
@@ -31,7 +31,7 @@ import {
   getSupportedLanguagePairs,
   resolveOpusMtTranslationRoute,
 } from '../offscreen/model-maps';
-import { getOpusMtPipelineConfig, preloadOpusMtModel } from '../offscreen/opus-runtime';
+import { getOpusMtPipelineAttempts, preloadOpusMtModel } from '../offscreen/opus-runtime';
 import { getCachedPipeline, cachePipeline, castAsPipeline } from '../offscreen/pipeline-cache';
 import { buildLanguageDetectionSample, detectLanguage } from '../offscreen/language-detection';
 import { translateWithGemma, getTranslateGemmaPipeline } from '../offscreen/translategemma';
@@ -66,6 +66,7 @@ const log = createLogger('Background-FF');
 env.allowRemoteModels = true;  // Models from HuggingFace Hub
 env.allowLocalModels = false;  // No local filesystem
 env.useBrowserCache = true;    // Cache models in IndexedDB
+env.useWasmCache = true;       // Reuse compiled WASM artifacts when supported
 
 // Point ONNX Runtime to bundled WASM files
 const wasmBasePath = getURL('assets/');
@@ -171,17 +172,39 @@ async function getPipeline(sourceLang: string, targetLang: string): Promise<Tran
 
   log.info(`Loading model: ${modelId}`);
 
-  const { device, dtype } = getOpusMtPipelineConfig(await detectWebGPUCapabilities());
-  log.info(`Using device: ${device}, dtype: ${dtype}`);
-
-  const pipe = await withTimeout(
-    pipeline('translation', modelId, { device, dtype }),
-    CONFIG.timeouts.opusMtDirectMs,
-    `Loading model ${modelId}`
+  const webgpuProbe = CONFIG.experimental?.opusMtWebgpuProbe === true;
+  const capabilities = webgpuProbe ? await detectWebGPUCapabilities() : { supported: false, fp16: false };
+  const attempts = getOpusMtPipelineAttempts(capabilities, { webgpuProbe });
+  log.info(
+    `Runtime attempts: ${attempts.map((attempt) => `${attempt.device}/${attempt.dtype}`).join(', ')}`
   );
 
+  let pipe: unknown;
+  let loadedDevice: 'wasm' | 'webgpu' = 'wasm';
+  let lastError: unknown;
+
+  for (const attempt of attempts) {
+    try {
+      log.info(`Trying ${attempt.label} for ${modelId}`);
+      pipe = await withTimeout(
+        pipeline('translation', modelId, { device: attempt.device, dtype: attempt.dtype }),
+        CONFIG.timeouts.opusMtDirectMs,
+        `Loading model ${modelId}`
+      );
+      loadedDevice = attempt.device;
+      break;
+    } catch (error) {
+      lastError = error;
+      log.warn(`${attempt.label} failed for ${modelId}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  if (!pipe) {
+    throw lastError instanceof Error ? lastError : new Error(`Failed to load model ${modelId}`);
+  }
+
   cachePipeline(modelId, castAsPipeline(pipe));
-  log.info(`Model loaded: ${modelId}`);
+  log.info(`Model loaded: ${modelId} on ${loadedDevice}`);
 
   return castAsPipeline(pipe);
 }

--- a/src/offscreen/offscreen.test.ts
+++ b/src/offscreen/offscreen.test.ts
@@ -15,7 +15,12 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mockCanvasElement, setupImageConstructorMock } from '../test-helpers/dom-property-mocks';
-import { selectOpusMtDtype } from './opus-runtime';
+import {
+  getDefaultOpusMtPipelineConfig,
+  getOpusMtPipelineAttempts,
+  getOpusMtPipelineConfig,
+  selectOpusMtDtype,
+} from './opus-runtime';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1778,6 +1783,47 @@ describe('selectOpusMtDtype', () => {
     expect(selectOpusMtDtype({ supported: true, fp16: true })).toBe('q8');
     expect(selectOpusMtDtype({ supported: true, fp16: false })).toBe('q8');
     expect(selectOpusMtDtype({ supported: false, fp16: false })).toBe('q8');
+  });
+});
+
+describe('OPUS-MT runtime attempts', () => {
+  it('uses wasm/q8 by default even when WebGPU is supported', () => {
+    expect(getOpusMtPipelineConfig({ supported: true, fp16: true })).toEqual({
+      device: 'wasm',
+      dtype: 'q8',
+      label: 'WASM+q8',
+    });
+  });
+
+  it('adds a WebGPU probe attempt only when explicitly enabled', () => {
+    expect(
+      getOpusMtPipelineAttempts(
+        { supported: true, fp16: true },
+        { webgpuProbe: true }
+      )
+    ).toEqual([
+      { device: 'webgpu', dtype: 'q8', label: 'WebGPU+q8 probe' },
+      { device: 'wasm', dtype: 'q8', label: 'WASM+q8' },
+    ]);
+  });
+
+  it('falls back to wasm/q8 when the probe flag is enabled but WebGPU is unavailable', () => {
+    expect(
+      getOpusMtPipelineAttempts(
+        { supported: false, fp16: false },
+        { webgpuProbe: true }
+      )
+    ).toEqual([
+      { device: 'wasm', dtype: 'q8', label: 'WASM+q8' },
+    ]);
+  });
+
+  it('exposes the production default as a stable helper', () => {
+    expect(getDefaultOpusMtPipelineConfig()).toEqual({
+      device: 'wasm',
+      dtype: 'q8',
+      label: 'WASM+q8',
+    });
   });
 });
 

--- a/src/offscreen/offscreen.ts
+++ b/src/offscreen/offscreen.ts
@@ -17,7 +17,7 @@ import {
   getSupportedLanguagePairs,
   resolveOpusMtTranslationRoute,
 } from './model-maps';
-import { getOpusMtPipelineConfig, preloadOpusMtModel } from './opus-runtime';
+import { getOpusMtPipelineAttempts, preloadOpusMtModel } from './opus-runtime';
 import {
   collectBatchTranslationInputs,
   mergeBatchTranslationResults,
@@ -87,6 +87,7 @@ async function getTransformers(): Promise<TransformersLib> {
   lib.env.allowRemoteModels = true;
   lib.env.allowLocalModels = false;
   lib.env.useBrowserCache = true;
+  lib.env.useWasmCache = true;
   /* v8 ignore start */
   if (lib.env.backends?.onnx?.wasm) {
     lib.env.backends.onnx.wasm.wasmPaths = wasmBasePath;
@@ -136,46 +137,59 @@ async function getPipeline(sourceLang: string, targetLang: string, sessionId?: s
   log.info(` Loading model: ${modelId}`);
   const loadStart = performance.now();
 
-  // OPUS-MT models MUST use WASM device. WebGPU causes degenerate output
-  // (repeated words like "Figure Figure..." or "Switzerland Switzerland...")
-  // with q8-quantized Marian models. WebGPU is only viable for models with
-  // dedicated fp16 ONNX files (e.g., TranslateGemma).
-  const { device, dtype } = getOpusMtPipelineConfig({ supported: false, fp16: false });
-  log.info(` Using device: ${device}, dtype: ${dtype}`);
+  const webgpuProbe = CONFIG.experimental.opusMtWebgpuProbe;
+  const capabilities = webgpuProbe ? await detectWebGPU() : { supported: false, fp16: false };
+  const attempts = getOpusMtPipelineAttempts(capabilities, { webgpuProbe });
+  log.info(
+    ` Runtime attempts: ${attempts.map((attempt) => `${attempt.device}/${attempt.dtype}`).join(', ')}`
+  );
 
   // Use optimized timeout for OPUS-MT direct models (~85MB quantized, typically loads in <30s)
   // If WebGPU fails (GPU incompatibility), fall back to WASM+q8 automatically.
-  let pipe;
-  try {
-    reportModelProgress(modelId, { status: 'initiate', progress: 0 });
-    pipe = await withTimeout(
-      (await getTransformers()).pipeline('translation', modelId, {
-        device,
-        dtype,
-        progress_callback: (progress: Record<string, unknown>) => {
-          reportModelProgress(modelId, {
-            status: normalizeProgressStatus(progress.status),
-            progress: typeof progress.progress === 'number' ? progress.progress : undefined,
-            file: typeof progress.file === 'string' ? progress.file : undefined,
-            loaded: typeof progress.loaded === 'number' ? progress.loaded : undefined,
-            total: typeof progress.total === 'number' ? progress.total : undefined,
-          });
-        },
-      } as Record<string, unknown>),
-      CONFIG.timeouts.opusMtDirectMs,
-      `Loading model ${modelId}`
-    );
-  } catch (error) {
-    /* v8 ignore start -- defensive rethrow */
-    throw error;
-    /* v8 ignore stop */
+  let pipe: unknown;
+  let loadedDevice: 'wasm' | 'webgpu' = 'wasm';
+  let lastError: unknown;
+
+  for (const attempt of attempts) {
+    try {
+      log.info(` Trying ${attempt.label} for ${modelId}`);
+      reportModelProgress(modelId, { status: 'initiate', progress: 0 });
+      pipe = await withTimeout(
+        (await getTransformers()).pipeline('translation', modelId, {
+          device: attempt.device,
+          dtype: attempt.dtype,
+          progress_callback: (progress: Record<string, unknown>) => {
+            reportModelProgress(modelId, {
+              status: normalizeProgressStatus(progress.status),
+              progress: typeof progress.progress === 'number' ? progress.progress : undefined,
+              file: typeof progress.file === 'string' ? progress.file : undefined,
+              loaded: typeof progress.loaded === 'number' ? progress.loaded : undefined,
+              total: typeof progress.total === 'number' ? progress.total : undefined,
+            });
+          },
+        } as Record<string, unknown>),
+        CONFIG.timeouts.opusMtDirectMs,
+        `Loading model ${modelId}`
+      );
+      loadedDevice = attempt.device;
+      break;
+    } catch (error) {
+      lastError = error;
+      log.warn(`${attempt.label} failed for ${modelId}: ${extractErrorMessage(error)}`);
+    }
+  }
+
+  if (!pipe) {
+    throw lastError instanceof Error
+      ? lastError
+      : new Error(`Failed to load model ${modelId}: ${extractErrorMessage(lastError)}`);
   }
 
   const loadDuration = performance.now() - loadStart;
   if (sessionId) {
-    profiler.recordTiming(sessionId, 'model_load', loadDuration, { cached: false, modelId, device });
+    profiler.recordTiming(sessionId, 'model_load', loadDuration, { cached: false, modelId, device: loadedDevice });
   }
-  log.info(` Model loaded: ${modelId} in ${loadDuration.toFixed(0)}ms`);
+  log.info(` Model loaded: ${modelId} in ${loadDuration.toFixed(0)}ms on ${loadedDevice}`);
 
   // Store in LRU cache (may evict old models)
   cachePipeline(modelId, castAsPipeline(pipe));

--- a/src/offscreen/opus-runtime.ts
+++ b/src/offscreen/opus-runtime.ts
@@ -7,25 +7,60 @@ export interface OpusMtRuntimeCapabilities {
 }
 
 export interface OpusMtPipelineConfig {
-  device: 'wasm';
+  device: 'wasm' | 'webgpu';
   dtype: 'q8';
+  label: string;
+}
+
+export interface OpusMtPipelineOptions {
+  webgpuProbe?: boolean;
 }
 
 /**
  * OPUS-MT Marian checkpoints only ship q8 ONNX assets. Running them through
- * WebGPU currently causes degenerate repeated-token output, so keep the
- * runtime pinned to wasm/q8 until a browser-safe GPU path is proven.
+ * WebGPU has caused degenerate repeated-token output with OPUS-MT Marian
+ * checkpoints, so production stays pinned to wasm/q8. The optional probe path
+ * is only for measuring whether the v4 runtime is stable enough to revisit.
  */
 export function selectOpusMtDtype(_capabilities: OpusMtRuntimeCapabilities): 'q8' {
   return 'q8';
 }
 
 export function getOpusMtPipelineConfig(
-  capabilities: OpusMtRuntimeCapabilities
+  capabilities: OpusMtRuntimeCapabilities,
+  options: OpusMtPipelineOptions = {}
 ): OpusMtPipelineConfig {
-  return {
+  return getOpusMtPipelineAttempts(capabilities, options)[0];
+}
+
+export function getOpusMtPipelineAttempts(
+  capabilities: OpusMtRuntimeCapabilities,
+  options: OpusMtPipelineOptions = {}
+): OpusMtPipelineConfig[] {
+  const attempts: OpusMtPipelineConfig[] = [];
+
+  if (options.webgpuProbe === true && capabilities.supported) {
+    attempts.push({
+      device: 'webgpu',
+      dtype: selectOpusMtDtype(capabilities),
+      label: 'WebGPU+q8 probe',
+    });
+  }
+
+  attempts.push({
     device: 'wasm',
     dtype: selectOpusMtDtype(capabilities),
+    label: 'WASM+q8',
+  });
+
+  return attempts;
+}
+
+export function getDefaultOpusMtPipelineConfig(): OpusMtPipelineConfig {
+  return {
+    device: 'wasm',
+    dtype: 'q8',
+    label: 'WASM+q8',
   };
 }
 

--- a/src/spikes/transformers-v4-webgpu-spike.test.ts
+++ b/src/spikes/transformers-v4-webgpu-spike.test.ts
@@ -1,0 +1,146 @@
+import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+interface SpikeModule {
+  buildTransformersEnvSettings: (
+    options: { offline?: boolean; cacheDir?: string }
+  ) => {
+    allowRemoteModels: boolean;
+    allowLocalModels: boolean;
+    useBrowserCache: boolean;
+    useFSCache: boolean;
+    useWasmCache: boolean;
+    cacheDir: string;
+  };
+  calculateMemoryDelta: (
+    before: { rss: number; heapUsed: number; external: number },
+    after: { rss: number; heapUsed: number; external: number }
+  ) => { rssBytes: number; heapUsedBytes: number; externalBytes: number } | null;
+  estimateTokenCount: (text: string) => number;
+  parseSpikeArgs: (argv: string[]) => {
+    model: string;
+    device: string;
+    dtype: string;
+    text: string;
+    cacheDir: string;
+    offline: boolean;
+    maxLength: number;
+  };
+  resolveSpikeDevice: (requestedDevice: string, hasWebGpu: boolean, isNodeRuntime?: boolean) => string;
+  runSpike: (options: { device: string }) => Promise<unknown>;
+  summarizeInferenceMetrics: (input: {
+    loadMs: number;
+    inferenceMs: number;
+    outputText: string;
+    memoryBefore: { rss: number; heapUsed: number; external: number };
+    memoryAfter: { rss: number; heapUsed: number; external: number };
+  }) => {
+    loadMs: number;
+    inferenceMs: number;
+    estimatedOutputTokens: number;
+    estimatedTokensPerSecond: number;
+    memoryDelta: { rssBytes: number; heapUsedBytes: number; externalBytes: number } | null;
+  };
+}
+
+async function loadSpikeModule(): Promise<SpikeModule> {
+  return import(
+    pathToFileURL(resolve(process.cwd(), 'scripts/transformers-v4-webgpu-spike.mjs')).href
+  ) as Promise<SpikeModule>;
+}
+
+describe('Transformers.js v4 WebGPU spike script helpers', () => {
+  it('parses explicit CLI options', async () => {
+    const { parseSpikeArgs } = await loadSpikeModule();
+
+    expect(parseSpikeArgs([
+      '--model=Xenova/opus-mt-en-fi',
+      '--device=wasm',
+      '--dtype=q8',
+      '--text=Hello',
+      '--cache-dir=/tmp/transformers-cache',
+      '--max-length=64',
+      '--offline',
+    ])).toEqual({
+      model: 'Xenova/opus-mt-en-fi',
+      device: 'wasm',
+      dtype: 'q8',
+      text: 'Hello',
+      cacheDir: '/tmp/transformers-cache',
+      offline: true,
+      maxLength: 64,
+    });
+  });
+
+  it('rejects unsupported devices', async () => {
+    const { parseSpikeArgs } = await loadSpikeModule();
+
+    expect(() => parseSpikeArgs(['--device=webnn'])).toThrow(/Unsupported device/);
+  });
+
+  it('resolves auto device from WebGPU availability', async () => {
+    const { resolveSpikeDevice } = await loadSpikeModule();
+
+    expect(resolveSpikeDevice('auto', true)).toBe('webgpu');
+    expect(resolveSpikeDevice('auto', false)).toBe('cpu');
+    expect(resolveSpikeDevice('auto', false, false)).toBe('wasm');
+    expect(resolveSpikeDevice('wasm', true)).toBe('cpu');
+    expect(resolveSpikeDevice('wasm', true, false)).toBe('wasm');
+  });
+
+  it('estimates token count conservatively from text length', async () => {
+    const { estimateTokenCount } = await loadSpikeModule();
+
+    expect(estimateTokenCount('')).toBe(0);
+    expect(estimateTokenCount('test')).toBe(1);
+    expect(estimateTokenCount('123456789')).toBe(3);
+  });
+
+  it('summarizes latency, throughput, and memory deltas', async () => {
+    const { summarizeInferenceMetrics } = await loadSpikeModule();
+
+    expect(summarizeInferenceMetrics({
+      loadMs: 1234.4,
+      inferenceMs: 250,
+      outputText: 'translated output',
+      memoryBefore: { rss: 1000, heapUsed: 500, external: 100 },
+      memoryAfter: { rss: 1500, heapUsed: 650, external: 130 },
+    })).toEqual({
+      loadMs: 1234,
+      inferenceMs: 250,
+      estimatedOutputTokens: 5,
+      estimatedTokensPerSecond: 20,
+      memoryDelta: {
+        rssBytes: 500,
+        heapUsedBytes: 150,
+        externalBytes: 30,
+      },
+    });
+  });
+
+  it('returns null memory deltas when snapshots are unavailable', async () => {
+    const { calculateMemoryDelta } = await loadSpikeModule();
+
+    expect(calculateMemoryDelta(null as never, { rss: 1, heapUsed: 1, external: 1 })).toBeNull();
+  });
+
+  it('allows local cache reads when offline mode disables remote fetches', async () => {
+    const { buildTransformersEnvSettings } = await loadSpikeModule();
+
+    expect(buildTransformersEnvSettings({ offline: true, cacheDir: '/tmp/cache' })).toMatchObject({
+      allowRemoteModels: false,
+      allowLocalModels: true,
+      useBrowserCache: false,
+      useFSCache: true,
+      useWasmCache: true,
+      cacheDir: '/tmp/cache',
+    });
+  });
+
+  it('fails fast when WebGPU is requested in a runtime without navigator.gpu', async () => {
+    const { runSpike } = await loadSpikeModule();
+
+    await expect(runSpike({ device: 'webgpu' })).rejects.toThrow(/navigator\.gpu is not available/);
+  });
+});


### PR DESCRIPTION
## Summary
- Upgrades @huggingface/transformers to v4.2.0.
- Keeps OPUS-MT production runtime on wasm/q8 while adding a VITE_OPUS_MT_WEBGPU_PROBE=true WebGPU-first probe with wasm fallback.
- Adds a repeatable Transformers.js v4 measurement harness plus helper tests and updates the spike handoff doc.
- Pins fast-uri via overrides to clear the npm audit finding surfaced during install.

## Validation
- npm run build
- npm run typecheck
- npm run lint
- npm run test
- npm audit --json
- npm run spike:transformers-v4 -- --device=cpu --text="Hello world. I like apples." --max-length=64
- npm run spike:transformers-v4 -- --device=cpu --offline --text="Hello world. I like apples." --max-length=64

## Notes
- Node WebGPU is blocked because this runtime has no navigator.gpu; browser WebGPU remains probe-only and disabled by default until the Chrome/Firefox/Safari matrix is recorded.

Closes #508