### PR TITLE
chore(security): land stranded TX-03 + TX-04 commits (MIK-2973 follow-up)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -3,6 +3,13 @@ name: AI Review
 on:
   pull_request:
 
+# TX-04 (MIK-2973): explicit minimal permissions block.
+# Without this, the GITHUB_TOKEN defaults to write-all under classic repos.
+# This workflow only needs to post a PR comment, so grant only what's needed.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ai_review:
     if: ${{ vars.AI_REVIEW_ENABLED == 'true' }}

--- a/.github/workflows/sign-extension.yml
+++ b/.github/workflows/sign-extension.yml
@@ -22,14 +22,25 @@ jobs:
             echo "CRX_PRIVATE_KEY secret is required to sign the extension" >&2
             exit 1
           fi
-      - name: Decode signing key
+      - name: Decode, sign, and clean
+        # TX-01 (MIK-2973): key.pem is removed via EXIT trap even if signing
+        # fails mid-step. Previously decode + pack + rm were three separate
+        # steps; a failure in `bash scripts/pack-extension.sh ...` would leave
+        # key.pem on disk and risk inclusion in subsequent artifact upload.
+        # Matches the pattern already in publish.yml.
         env:
           CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
         run: |
+          trap "rm -f key.pem" EXIT
           echo "$CRX_PRIVATE_KEY" | base64 -d > key.pem
-      - name: Pack and sign
-        run: |
           bash scripts/pack-extension.sh translate-by-mikko-extension key.pem
+          # NOTE: CRX_PRIVATE_KEY secret rotation steps (TX-01):
+          #   1. Generate new key: openssl genrsa -out new_key.pem 2048
+          #   2. base64-encode: base64 -i new_key.pem | tr -d '\n'
+          #   3. Update repo secret CRX_PRIVATE_KEY with the encoded value
+          #   4. Revoke/replace old key in Chrome Web Store developer settings
+          # The old key is not revocable from GHA; only the CWS developer
+          # dashboard controls which key is trusted for your extension ID.
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
@@ -37,4 +48,4 @@ jobs:
           path: |
             translate-by-mikko-extension.crx
             translate-by-mikko-extension.zip
-      - run: rm -f key.pem
+      # key.pem cleanup is handled by the EXIT trap in the 'Decode, sign, and clean' step above.


### PR DESCRIPTION
Two operator-authored security commits that landed on local main but were never pushed. MIK-2973 closure (2026-05-17) cites them as evidence; their absence on origin was a stale-state issue.

## Commits

- `ba2ea3f` — fix(security): TX-03 trap key.pem cleanup in sign-extension.yml (MIK-2973)
- `e97452b` — fix(security): TX-04 minimal permissions block on ai-review.yml (MIK-2973)

Both authored by Mikko Parkkola directly. No code changes from this PR — pure push-the-stranded-commits.

Direct-push to main was blocked by branch protection (correct guardrail). Wrapping in a PR for proper review trail.

— elite-loop autonomous tick