### PR TITLE
chore(gitignore): ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ generate_icons.py
 vitest-coverage-measure.config.ts
 coverage.json
 reports/
+.claude/worktrees/


### PR DESCRIPTION
Mirror the existing `.claude/agent-memory/` ignore pattern for the harness worktree scratch directory. Prevents agent runs from polluting working-tree status.

Single-line addition. — elite-loop autonomous tick