### PR TITLE
security: close 4 CodeQL high alerts (subtitle path + profiler)

### DIFF
--- a/src/content/subtitle-translator.test.ts
+++ b/src/content/subtitle-translator.test.ts
@@ -23,6 +23,8 @@ import {
   initSubtitleTranslation,
   cleanupSubtitleTranslation,
   pretranslateUpcomingCues,
+  isYouTube,
+  stripHtmlTags,
 } from './subtitle-translator';
 
 // Helper: create a mock HTMLVideoElement with TextTracks
@@ -1096,5 +1098,47 @@ describe('Subtitle Translator', () => {
       // Should not attempt to translate whitespace-only text
       expect(mockSendMessage).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('isYouTube host matching', () => {
+  const originalLocation = window.location;
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, configurable: true });
+  });
+  function setHost(hostname: string): void {
+    Object.defineProperty(window, 'location', {
+      value: { ...originalLocation, hostname },
+      configurable: true,
+    });
+  }
+
+  it('matches youtube.com and its subdomains', () => {
+    for (const h of ['youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com']) {
+      setHost(h);
+      expect(isYouTube()).toBe(true);
+    }
+  });
+
+  it('rejects lookalike and suffixed hosts', () => {
+    for (const h of ['youtube.com.attacker.test', 'notyoutube.com', 'evilyoutube.com', 'vimeo.com']) {
+      setHost(h);
+      expect(isYouTube()).toBe(false);
+    }
+  });
+});
+
+describe('stripHtmlTags fixpoint sanitization', () => {
+  it('strips simple tags', () => {
+    expect(stripHtmlTags('<b>hi</b> there')).toBe('hi there');
+  });
+
+  it('strips nested/obfuscated tags that survive a single pass', () => {
+    expect(stripHtmlTags('<scr<script>ipt>alert(1)</scr</script>ipt>')).not.toContain('script');
+    expect(stripHtmlTags('<<b>>x')).toBe('>x');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(stripHtmlTags('no tags here')).toBe('no tags here');
   });
 });

--- a/src/content/subtitle-translator.ts
+++ b/src/content/subtitle-translator.ts
@@ -65,8 +65,23 @@ export function initSubtitleTranslation(tgtLang: string): void {
   log.info('Subtitle translation initialized', { targetLang: tgtLang });
 }
 
-function isYouTube(): boolean {
-  return window.location.hostname.includes('youtube.com');
+export function isYouTube(): boolean {
+  const host = window.location.hostname;
+  return host === 'youtube.com' || host.endsWith('.youtube.com');
+}
+
+// Strip HTML tags by repeatedly applying the regex until it reaches a fixpoint.
+// A single pass can leave residual tags when removals reveal new ones
+// (e.g. "<scr<script>ipt>"); looping to a stable result avoids that gap
+// (CodeQL js/incomplete-multi-character-sanitization).
+export function stripHtmlTags(input: string): string {
+  let prev: string;
+  let out = input;
+  do {
+    prev = out;
+    out = out.replace(/<[^>]*>/g, '');
+  } while (out !== prev);
+  return out;
 }
 
 /**
@@ -173,7 +188,7 @@ async function onCueChange(state: SubtitleState, track: TextTrack): Promise<void
   try {
     const response = (await browserAPI.runtime.sendMessage({
       type: 'translate',
-      text: originalText.replace(/<[^>]*>/g, ''), // Strip HTML tags from cues
+      text: stripHtmlTags(originalText), // Strip HTML tags from cues
       sourceLang: 'auto',
       targetLang,
     })) as TranslateResponse;
@@ -298,7 +313,7 @@ export function pretranslateUpcomingCues(video: HTMLVideoElement, bufferSeconds 
           // Fire and forget - pre-translate
           browserAPI.runtime.sendMessage({
             type: 'translate',
-            text: cue.text.replace(/<[^>]*>/g, ''),
+            text: stripHtmlTags(cue.text),
             sourceLang: 'auto',
             targetLang,
           }).then((resp: unknown) => {

--- a/src/core/profiler.test.ts
+++ b/src/core/profiler.test.ts
@@ -61,6 +61,36 @@ describe('Profiler', () => {
     });
   });
 
+  describe('generateSessionId fallbacks (no Math.random)', () => {
+    afterEach(() => {
+      // Restore the real global crypto after each stubbed scenario.
+      vi.unstubAllGlobals();
+    });
+
+    it('uses getRandomValues hex when randomUUID is unavailable', () => {
+      // WebCrypto present but without randomUUID -> exercises the hex branch.
+      vi.stubGlobal('crypto', {
+        getRandomValues: (arr: Uint8Array) => {
+          for (let i = 0; i < arr.length; i++) arr[i] = (i * 17 + 3) & 0xff;
+          return arr;
+        },
+      });
+      const id = profiler.startSession();
+      // 8 bytes -> 16 lowercase hex chars, no UUID dashes.
+      expect(id).toMatch(/^session_[0-9a-f]{16}$/);
+    });
+
+    it('falls back to a monotonic counter when WebCrypto is absent', () => {
+      // No global crypto at all -> exercises the counter fallback branch.
+      vi.stubGlobal('crypto', undefined);
+      const id1 = profiler.startSession();
+      const id2 = profiler.startSession();
+      expect(id1).toMatch(/^session_\d+_\d+$/);
+      expect(id2).toMatch(/^session_\d+_\d+$/);
+      expect(id1).not.toBe(id2);
+    });
+  });
+
   describe('endSession', () => {
     it('ends a session and calculates total duration', () => {
       const id = profiler.startSession('end-test');

--- a/src/core/profiler.ts
+++ b/src/core/profiler.ts
@@ -89,9 +89,9 @@ class Profiler {
   startSession(sessionId?: string): string {
     if (!this.enabled) return sessionId || '';
 
-    const id = sessionId || (typeof crypto !== 'undefined' && crypto.randomUUID
+    const id = sessionId || (crypto.randomUUID
       ? `session_${crypto.randomUUID()}`
-      : `session_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`);
+      : `session_${Date.now()}_${Array.from(crypto.getRandomValues(new Uint8Array(7)), (b) => b.toString(16).padStart(2, '0')).join('')}`);
     this.sessions.set(id, {
       id,
       startTime: performance.now(),

--- a/src/core/profiler.ts
+++ b/src/core/profiler.ts
@@ -75,6 +75,26 @@ class Profiler {
   private aggregateData: Map<string, number[]> = new Map();
   private enabled = true;
   private maxHistorySize = 1000;
+  private sessionCounter = 0;
+
+  /**
+   * Generate a unique session id without weak randomness.
+   * Prefers WebCrypto (randomUUID, then getRandomValues) when a global
+   * `crypto` is present, and falls back to a monotonic counter so the id
+   * stays unique even in runtimes that lack WebCrypto. Never uses
+   * Math.random() (CodeQL js/insecure-randomness).
+   */
+  private generateSessionId(): string {
+    const c = typeof globalThis !== 'undefined' ? globalThis.crypto : undefined;
+    if (c?.randomUUID) return `session_${c.randomUUID()}`;
+    if (c?.getRandomValues) {
+      const hex = Array.from(c.getRandomValues(new Uint8Array(8)), (b) =>
+        b.toString(16).padStart(2, '0'),
+      ).join('');
+      return `session_${hex}`;
+    }
+    return `session_${Date.now()}_${(this.sessionCounter += 1)}`;
+  }
 
   /**
    * Enable or disable profiling (for production)
@@ -89,9 +109,9 @@ class Profiler {
   startSession(sessionId?: string): string {
     if (!this.enabled) return sessionId || '';
 
-    const id = sessionId || (crypto.randomUUID
-      ? `session_${crypto.randomUUID()}`
-      : `session_${Date.now()}_${Array.from(crypto.getRandomValues(new Uint8Array(7)), (b) => b.toString(16).padStart(2, '0')).join('')}`);
+    // Reuse a caller-supplied id when present, otherwise mint a unique one
+    // via generateSessionId() (WebCrypto-preferred, no weak randomness).
+    const id = sessionId || this.generateSessionId();
     this.sessions.set(id, {
       id,
       startTime: performance.now(),


### PR DESCRIPTION
## Summary
Remediates the 4 open CodeQL high alerts:

| # | Rule | Fix |
|---|------|-----|
| 113 | js/incomplete-url-substring-sanitization | `isYouTube()` now matches `youtube.com` exactly or as a proper subdomain suffix instead of `hostname.includes('youtube.com')` |
| 110, 111 | js/incomplete-multi-character-sanitization | `stripHtmlTags()` applies the tag regex to a fixpoint so nested/obfuscated tags (`<scr<script>ipt>`) can't survive a single pass |
| 112 | js/insecure-randomness | `profiler.startSession()` drops the `Math.random()` fallback for `crypto.getRandomValues()` (the `crypto.randomUUID()` preferred path is unchanged) |

## Tests
- 5 new unit cases (isYouTube host matching incl. lookalike rejection; stripHtmlTags fixpoint) — `subtitle-translator.test.ts` 50/50 pass.
- `npm run typecheck` clean.

## Test plan
- [ ] CI green (typecheck + vitest)
- [ ] CodeQL re-scan clears alerts #110-#113