### PR TITLE
fix(content): surface backend errors on batch translation failure

### DIFF
--- a/src/content/page-translation-orchestrator.ts
+++ b/src/content/page-translation-orchestrator.ts
@@ -265,13 +265,23 @@ export function createPageTranslationOrchestrator(
             try {
               translatedResults = normalizeBatchTranslations(response.result ?? [], batch.nodes.length);
             } catch (error) {
-              log.warn('Batch translation returned invalid result shape:', error);
+              log.warn(
+                `Batch translation returned invalid result shape (${sourceLang} -> ${targetLang}, provider=${provider}):`,
+                error,
+                'raw response.result:',
+                response.result
+              );
               return { translatedCount: 0, errorCount: batch.nodes.length, ipcTime, domUpdateTime: 0 };
             }
           } else {
             /* v8 ignore start -- non-retryable IPC error; requires real extension messaging */
-            // Non-retryable error (e.g. unsupported language pair)
+            // Non-retryable error (e.g. unsupported language pair, model load failure).
+            // Surface the actual backend error — without this the batch only logs
+            // "fully failed (N nodes)" and the real cause stays invisible.
             if (response.error && !isTransientError(response.error)) {
+              log.error(
+                `Batch failed, non-retryable (${sourceLang} -> ${targetLang}, provider=${provider}): ${response.error}`
+              );
               return { translatedCount: 0, errorCount: batch.nodes.length, ipcTime, domUpdateTime: 0 };
             }
 


### PR DESCRIPTION
## Summary
- Batch translation failures previously logged opaque messages ("invalid result shape", "fully failed (N nodes)") with the real backend cause invisible.
- Adds language pair + provider context to the invalid-shape warning plus the raw `response.result`.
- Emits an explicit `log.error` on non-retryable batch failures (unsupported language pair, model load failure) so the actual cause is diagnosable from the console.

Logging-only change inside `createPageTranslationOrchestrator`; no behavior change.

## Verification
- `npm run typecheck` — clean
- `npm run test` — 5051/5051 passing
- `npm run build` — clean (dist/content.js 90.18 kB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)