### PR TITLE
ci: gate builds + releases on known dependency vulnerabilities

### DIFF
--- a/.github/osv-scanner.toml
+++ b/.github/osv-scanner.toml
@@ -1,0 +1,39 @@
+# osv-scanner allowlist — the pressure valve for the CI/release security gate.
+#
+# This gate fails the build on ANY known, fixable vulnerability in the npm
+# dependency tree. It runs at the release/publish layer as a backstop:
+#   - release.yml `security-gate` job -> blocks `npm publish` + GitHub release
+#   - publish.yml `security-gate` job -> blocks the signed CRX dev build that
+#     users pull via updates.xml
+#
+# It is COMPLEMENTARY to, not a replacement for, the existing pre-merge gate.
+# ci.yml runs `npm audit --audit-level=high` on every PR — fast feedback, but it
+# only fails on HIGH+ severity. osv-scanner has NO severity threshold: it flags
+# every dep with a known OSV advisory, including moderate/low ones that
+# `--audit-level=high` deliberately lets through. So the release gate is the
+# stricter backstop that catches what slips past CI before anything ships.
+#
+# Scope: npm — osv-scanner reads package-lock.json (auto-detected) and checks
+# every dependency in the locked tree against the OSV database. NOT covered:
+# github-actions advisories (our actions are SHA-pinned, which is itself the
+# mitigation, and osv-scanner does not map SHA pins to advisory versions). There
+# is no Docker image in this repo, so no image-layer scan is needed.
+#
+# Failing on any fixable vuln is intentional: a new build must include the
+# security fixes that are available. Dependabot PROPOSES the bump PR; this gate
+# DISPOSES — it refuses to ship until the fix is merged.
+#
+# When a vulnerability has NO upstream fix yet, or is verified unreachable, it
+# would otherwise block every release indefinitely. Add a time-boxed exception
+# here instead of weakening the gate. Each entry MUST carry a reason and an
+# ignoreUntil review date — expired entries re-trigger the gate automatically.
+#
+# Format (https://google.github.io/osv-scanner/configuration/):
+#
+#   [[IgnoredVulns]]
+#   id = "GHSA-xxxx-xxxx-xxxx"
+#   ignoreUntil = 2026-07-01   # review by this date; after it the gate fires again
+#   reason = "No patched release upstream yet; reviewed 2026-06-05 by <who>."
+#
+# Keep this list EMPTY unless a vuln genuinely has no fix. The right fix for a
+# fixable vuln is to bump the dependency, not to ignore it.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,26 @@ permissions:
   contents: write
 
 jobs:
+  # Dependency-vulnerability backstop for the dev-build publish path. publish.yml
+  # signs a CRX and commits updates.xml, which is what installed extensions pull
+  # auto-updates from — so a vulnerable dependency would ship straight to users.
+  # Same lockfile-based OSV scan as the release gate; no severity threshold.
+  # Accepted/unfixable vulns are time-boxed in .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block dev build on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan npm dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   build:
+    needs: security-gate
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,27 @@ permissions:
   packages: write
 
 jobs:
+  # Dependency-vulnerability backstop. ci.yml gates PRs on
+  # `npm audit --audit-level=high` (HIGH+ only). This gate has no severity
+  # threshold — it fails on ANY known, fixable vuln in package-lock.json — and
+  # runs on the push-to-main release path so nothing publishes to npm / cuts a
+  # GitHub release while a fix is available but unmerged. Accepted/unfixable
+  # vulns are time-boxed in .github/osv-scanner.toml.
+  security-gate:
+    name: Security gate (block release on known vulns)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Scan npm dependencies against OSV
+        uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+        with:
+          scan-args: |-
+            --config=.github/osv-scanner.toml
+            --recursive
+            ./
+
   release:
+    needs: security-gate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## ci: gate releases + dev builds on known dependency vulnerabilities

Adds an `osv-scanner` dependency-vulnerability gate to the two publishing paths so a build cannot ship to npm, cut a GitHub release, or push a signed CRX while a fixable vulnerability sits in the locked dependency tree.

### What changed

- **`.github/osv-scanner.toml`** (new) — empty, npm-flavored allowlist with documented policy for time-boxed exceptions. Kept empty by design; the right fix for a fixable vuln is to bump the dependency, not ignore it.
- **`.github/workflows/release.yml`** — new `security-gate` job (checkout + osv-scanner). The `release` job (`npm publish` + GitHub release) now declares `needs: security-gate`.
- **`.github/workflows/publish.yml`** — new `security-gate` job. The `build` job (signs the CRX and commits `updates.xml`, which installed extensions auto-update from) now declares `needs: security-gate`.

### Why this and not a new CI job (non-redundancy)

`ci.yml` already runs `npm audit --audit-level=high` on every PR with no `continue-on-error` — a genuinely blocking pre-merge dep-vuln gate. Adding a second scanner to PR CI would be redundant, so this PR does **not** touch `ci.yml` or the existing audit.

The two scanners are complementary, not duplicative:

- `npm audit --audit-level=high` (CI, pre-merge): fast feedback, but **fails only on HIGH+ severity**.
- `osv-scanner` (release/publish, push-to-main): **no severity threshold** — fails on any known fixable OSV advisory, including the moderate/low ones `--audit-level=high` lets through. It is the stricter backstop at the layer that actually ships.

CodeQL and Semgrep are SAST (source-code analysis) and do not gate dependency vulnerabilities; SBOM only inventories. None of them count as a dep-vuln gate.

### DAG wiring

```
release.yml:  security-gate ──needs──▶ release (npm publish + GitHub release)   [root was ungated]
publish.yml:  security-gate ──needs──▶ build   (sign CRX + commit updates.xml)  [root was ungated]
```

Both publishing roots were previously ungated `push: [main]` triggers. The gate now sits in front of each.

### ⚠️ This gate is RED on `main` today — do not make `security-gate` a required check until green

`V:` local osv-scanner run from a clean worktree (lockfile-only, no `npm ci`), exact CI args (`--config=.github/osv-scanner.toml --recursive ./`), 2026-06-05:

```
Total 1 package affected by 1 known vulnerability
(0 Critical, 0 High, 1 Medium, 0 Low, 0 Unknown) from 1 ecosystem.
1 vulnerability can be fixed.
exit code 1
```

| OSV | CVSS | Ecosystem | Package | Current | Fixed |
|-----|------|-----------|---------|---------|-------|
| [GHSA-jxxr-4gwj-5jf2](https://osv.dev/GHSA-jxxr-4gwj-5jf2) | 6.5 (Medium) | npm | `brace-expansion` (dev, transitive) | 5.0.5 | **5.0.6** |

This is precisely why the gate is worth having: it is a **Medium**-severity vuln, so `npm audit --audit-level=high` does **not** flag it, but osv does. Only the top-level `node_modules/brace-expansion@5.0.5` is affected; the 1.x and 2.x copies in the tree are on a different, unaffected advisory line.

**Recommended merge order:**
1. Land a `brace-expansion` bump to `5.0.6` first (e.g. `npm update brace-expansion`), confirm `osv-scanner --config=.github/osv-scanner.toml --recursive ./` exits 0.
2. Then merge this wiring, or merge this PR now but **hold off marking `security-gate` as a required status check** until the bump lands — otherwise the next release/dev-build push to `main` will (correctly) be blocked.

The vuln was deliberately **not** silenced in `osv-scanner.toml`: it is fixable, so the fix is to bump, not to ignore.

### Pinning / scope

- `google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8` (full-SHA pinned).
- Reuses the repo's existing `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`.
- osv-scanner auto-detects `package-lock.json`; no `npm ci` needed (lockfile-based, mirrors the scan above). No Docker image in this repo, so no image scan.

`A:` Scoped to the two publishing workflows + one config file. No source/test/runtime code touched; existing gates unchanged (CI `npm audit` left intact). `I:` YAML of both touched workflows validated (`yaml.safe_load` OK); toml parsed successfully by osv-scanner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
