### PR TITLE
test: restore coverage gate after contextual TranslateGemma prompts (MIK-3469 follow-up)

### DIFF
--- a/src/content/context.test.ts
+++ b/src/content/context.test.ts
@@ -316,6 +316,100 @@ describe('getSegmentTranslationContext', () => {
       pageContext: 'Standalone Article > article body',
     });
   });
+
+  it('returns page-only context when the node has no block ancestor', () => {
+    document.title = 'Loose Text Page';
+    const text = document.createTextNode('orphan');
+    document.body.insertBefore(text, null);
+
+    const context = getSegmentTranslationContext(text);
+
+    expect(context).toEqual({
+      before: '',
+      after: '',
+      pageContext: 'Loose Text Page',
+    });
+  });
+
+  it('returns undefined when there is no block ancestor and no page context', () => {
+    const text = document.createTextNode('orphan');
+    document.body.insertBefore(text, null);
+
+    expect(getSegmentTranslationContext(text)).toBeUndefined();
+  });
+
+  it('returns page-only context when the node is inside a hidden subtree', () => {
+    document.title = 'Hidden Sidebar';
+    const aside = document.createElement('aside');
+    const hidden = document.createElement('span');
+    hidden.setAttribute('hidden', '');
+    hidden.appendChild(document.createTextNode('secret'));
+    aside.appendChild(hidden);
+    document.body.appendChild(aside);
+
+    const context = getSegmentTranslationContext(hidden.firstChild as Text);
+
+    expect(context).toEqual({
+      before: '',
+      after: '',
+      pageContext: 'Hidden Sidebar > sidebar',
+    });
+  });
+
+  it('returns undefined for a hidden node with no page context', () => {
+    const div = document.createElement('div');
+    const hidden = document.createElement('span');
+    hidden.setAttribute('aria-hidden', 'true');
+    hidden.appendChild(document.createTextNode('secret'));
+    div.appendChild(hidden);
+    document.body.appendChild(div);
+
+    expect(
+      getSegmentTranslationContext(hidden.firstChild as Text),
+    ).toBeUndefined();
+  });
+
+  it('returns page-only context for a whitespace-only target with visible siblings', () => {
+    document.title = 'Spacing Demo';
+    const article = document.createElement('article');
+    article.append(
+      document.createTextNode('Leading words'),
+      document.createTextNode('   '),
+      document.createTextNode('Trailing words'),
+    );
+    document.body.appendChild(article);
+
+    // The whitespace-only middle node is filtered out of the segment list,
+    // so it is never matched and only the page context survives.
+    const context = getSegmentTranslationContext(article.childNodes[1] as Text);
+
+    expect(context).toEqual({
+      before: '',
+      after: '',
+      pageContext: 'Spacing Demo > article body',
+    });
+  });
+
+  it('skips empty text nodes while collecting block context', () => {
+    const paragraph = document.createElement('p');
+    const empty = document.createTextNode('');
+    paragraph.append(
+      document.createTextNode('Visible before '),
+      empty,
+      document.createTextNode('TARGET'),
+      document.createTextNode(' visible after'),
+    );
+    document.body.appendChild(paragraph);
+
+    const target = paragraph.childNodes[2] as Text;
+    const context = getSegmentTranslationContext(target, {
+      surroundingChars: 60,
+    });
+
+    expect(context).not.toBeUndefined();
+    expect(context!.before).toContain('Visible before');
+    expect(context!.after).toContain('visible after');
+  });
 });
 
 // ============================================================================

--- a/src/offscreen/message-routing.test.ts
+++ b/src/offscreen/message-routing.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  routeOffscreenMessage,
+  type OffscreenMessageHandlers,
+  type OffscreenTargetedMessageRecord,
+} from './message-routing';
+
+// Minimal handler map: a single `ping` handler is enough to exercise both the
+// handled and unhandled routing branches without pulling in the full offscreen
+// runtime.
+function makeHandlers(): OffscreenMessageHandlers {
+  return {
+    ping: vi.fn().mockResolvedValue({ success: true }),
+  } as unknown as OffscreenMessageHandlers;
+}
+
+describe('routeOffscreenMessage', () => {
+  it('dispatches to the matching handler for a known string type', async () => {
+    const handlers = makeHandlers();
+    const message = {
+      target: 'offscreen',
+      type: 'ping',
+    } as OffscreenTargetedMessageRecord;
+
+    const response = await routeOffscreenMessage(message, handlers);
+
+    expect(response).toEqual({ success: true });
+    expect(handlers.ping).toHaveBeenCalledWith(message);
+  });
+
+  it('reports the unknown string type in the error message', async () => {
+    const handlers = makeHandlers();
+    const message = {
+      target: 'offscreen',
+      type: 'definitelyNotAHandler',
+    } as OffscreenTargetedMessageRecord;
+
+    const response = await routeOffscreenMessage(message, handlers);
+
+    expect(response).toEqual({
+      success: false,
+      error: 'Unknown type: definitelyNotAHandler',
+    });
+  });
+
+  it('coerces a non-string type via String() in the error message', async () => {
+    const handlers = makeHandlers();
+    const message = {
+      target: 'offscreen',
+      type: 42,
+    } as OffscreenTargetedMessageRecord;
+
+    const response = await routeOffscreenMessage(message, handlers);
+
+    expect(response).toEqual({
+      success: false,
+      error: 'Unknown type: 42',
+    });
+  });
+
+  it('coerces a missing (undefined) type via String()', async () => {
+    const handlers = makeHandlers();
+    const message = {
+      target: 'offscreen',
+    } as OffscreenTargetedMessageRecord;
+
+    const response = await routeOffscreenMessage(message, handlers);
+
+    expect(response).toEqual({
+      success: false,
+      error: 'Unknown type: undefined',
+    });
+  });
+});

--- a/src/offscreen/offscreen.test.ts
+++ b/src/offscreen/offscreen.test.ts
@@ -660,6 +660,28 @@ describe('offscreen message handler', () => {
       expect(r.success).toBe(false);
       expect(r.error as string).toMatch(/targetLang/);
     });
+
+    it('rejects an over-length sourceLang code', async () => {
+      const r = await dispatch({
+        type: 'translate',
+        text: 'hi',
+        sourceLang: 'x'.repeat(21),
+        targetLang: 'de',
+      });
+      expect(r.success).toBe(false);
+      expect(r.error as string).toMatch(/Invalid sourceLang/);
+    });
+
+    it('rejects an over-length targetLang code', async () => {
+      const r = await dispatch({
+        type: 'translate',
+        text: 'hi',
+        sourceLang: 'en',
+        targetLang: 'y'.repeat(21),
+      });
+      expect(r.success).toBe(false);
+      expect(r.error as string).toMatch(/Invalid targetLang/);
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -682,6 +704,40 @@ describe('offscreen message handler', () => {
       expect(r.success).toBe(true);
       expect(r.result).toBe('Hallo aus dem Cache');
       expect(fakePipe).not.toHaveBeenCalled();
+    });
+
+    it('defaults to the opus-mt provider when none is given', async () => {
+      mockCacheGet.mockResolvedValue('Hallo (default provider)');
+      const fakePipe = vi.fn();
+      mockGetCachedPipeline.mockReturnValue(fakePipe);
+
+      const r = await dispatch({
+        type: 'translate',
+        text: 'Hello',
+        sourceLang: 'en',
+        targetLang: 'de',
+      });
+
+      expect(r.success).toBe(true);
+      expect(r.result).toBe('Hallo (default provider)');
+      expect(fakePipe).not.toHaveBeenCalled();
+    });
+
+    it('forwards a string pageContext as translation context', async () => {
+      mockCacheGet.mockResolvedValue('Pankki (cached)');
+      const fakePipe = vi.fn();
+      mockGetCachedPipeline.mockReturnValue(fakePipe);
+
+      const r = await dispatch({
+        type: 'translate',
+        text: 'Bank',
+        sourceLang: 'en',
+        targetLang: 'fi',
+        pageContext: 'Financial news article',
+      });
+
+      expect(r.success).toBe(true);
+      expect(r.result).toBe('Pankki (cached)');
     });
   });
 

--- a/src/offscreen/translategemma-extended.test.ts
+++ b/src/offscreen/translategemma-extended.test.ts
@@ -165,6 +165,42 @@ describe('detectWebGPU', () => {
 });
 
 // ============================================================================
+// detectWebNN
+// ============================================================================
+
+describe('detectWebNN', () => {
+  it('returns false when navigator.ml is unavailable', async () => {
+    vi.stubGlobal('navigator', {});
+    const { detectWebNN } = await import('./translategemma');
+    expect(await detectWebNN()).toBe(false);
+  });
+
+  it('returns true when navigator.ml creates a GPU context', async () => {
+    const createContext = vi.fn().mockResolvedValue({ deviceType: 'gpu' });
+    vi.stubGlobal('navigator', { ml: { createContext } });
+    const { detectWebNN } = await import('./translategemma');
+    expect(await detectWebNN()).toBe(true);
+    expect(createContext).toHaveBeenCalledWith({ deviceType: 'gpu' });
+  });
+
+  it('returns false when createContext rejects', async () => {
+    vi.stubGlobal('navigator', {
+      ml: { createContext: vi.fn().mockRejectedValue(new Error('no NPU')) },
+    });
+    const { detectWebNN } = await import('./translategemma');
+    expect(await detectWebNN()).toBe(false);
+  });
+
+  it('returns false when createContext resolves to a falsy context', async () => {
+    vi.stubGlobal('navigator', {
+      ml: { createContext: vi.fn().mockResolvedValue(null) },
+    });
+    const { detectWebNN } = await import('./translategemma');
+    expect(await detectWebNN()).toBe(false);
+  });
+});
+
+// ============================================================================
 // getTranslateGemmaPipeline — no WebGPU
 // ============================================================================
 
@@ -564,6 +600,62 @@ describe('translateWithGemma', () => {
       'financial article',
     );
     expect(result).toBeDefined();
+  });
+
+  it('applies a per-segment context array to array input', async () => {
+    mockModel.generate.mockReset();
+    mockTokenizerFn.mockReset();
+    mockTokenizerFn.mockImplementation((input: string | string[]) => ({
+      input_ids: { dims: [Array.isArray(input) ? input.length : 1, 3] },
+    }));
+    mockModel.generate.mockResolvedValue({
+      tolist: vi.fn().mockReturnValue([
+        [1, 2, 3, 101],
+        [1, 2, 3, 202],
+      ]),
+    });
+    mockTokenizerFn.decode = vi.fn(
+      (ids: number[]) => `decoded:${ids.join(',')}`,
+    );
+
+    const { translateWithGemma, getTranslateGemmaPipeline } =
+      await import('./translategemma');
+    await getTranslateGemmaPipeline();
+    const result = await translateWithGemma(['bank', 'bank'], 'en', 'fi', [
+      { before: 'the river', after: 'overflowed' },
+      { before: 'deposit at the', after: 'this morning' },
+    ]);
+
+    expect(result).toEqual(['decoded:101', 'decoded:202']);
+    // Each segment prompt embeds its own bounded context.
+    const prompts = mockTokenizerFn.mock.calls[0][0] as string[];
+    expect(prompts[0]).toContain('Before: the river');
+    expect(prompts[1]).toContain('Before: deposit at the');
+  });
+
+  it('applies the first context array entry to a single string input', async () => {
+    mockModel.generate.mockReset();
+    mockTokenizerFn.mockReset();
+    mockTokenizerFn.mockImplementation((input: string | string[]) => ({
+      input_ids: { dims: [Array.isArray(input) ? input.length : 1, 3] },
+    }));
+    mockModel.generate.mockResolvedValue({
+      tolist: vi.fn().mockReturnValue([[1, 2, 3, 303]]),
+    });
+    mockTokenizerFn.decode = vi.fn(
+      (ids: number[]) => `decoded:${ids.join(',')}`,
+    );
+
+    const { translateWithGemma, getTranslateGemmaPipeline } =
+      await import('./translategemma');
+    await getTranslateGemmaPipeline();
+    const result = (await translateWithGemma('bank', 'en', 'fi', [
+      { before: 'standing on the', after: 'watching the water' },
+    ])) as string;
+
+    expect(result).toBe('decoded:303');
+    const prompt = mockTokenizerFn.mock.calls[0][0] as string;
+    expect(prompt).toContain('Before: standing on the');
   });
 });
 

--- a/src/offscreen/translategemma.test.ts
+++ b/src/offscreen/translategemma.test.ts
@@ -417,6 +417,96 @@ describe('formatTranslateGemmaPrompt with context parameter', () => {
       expect(prompt).toContain('Uutiset > Urheilu');
     });
   });
+
+  describe('whitespace-only string context', () => {
+    it('omits context line when the string normalizes to empty', () => {
+      const prompt = formatTranslateGemmaPrompt(
+        'Hello',
+        'en',
+        'fi',
+        '   \n\t ',
+      );
+      expect(prompt).not.toContain('Context:');
+      expect(prompt).not.toContain('disambiguation');
+    });
+
+    it('produces identical output to a no-context call', () => {
+      const withWhitespace = formatTranslateGemmaPrompt(
+        'Hello',
+        'en',
+        'fi',
+        '   ',
+      );
+      const withoutArg = formatTranslateGemmaPrompt('Hello', 'en', 'fi');
+      expect(withWhitespace).toBe(withoutArg);
+    });
+  });
+
+  describe('partial structured context', () => {
+    it('includes only the page field when before/after are empty', () => {
+      const prompt = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: '',
+        after: '',
+        pageContext: 'Finance Weekly > article body',
+      });
+      expect(prompt).toContain('Context:');
+      expect(prompt).toContain('Page: Finance Weekly > article body');
+      expect(prompt).not.toContain('Before:');
+      expect(prompt).not.toContain('After:');
+    });
+
+    it('includes only the before field when page/after are empty', () => {
+      const prompt = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: 'On the left river bank',
+        after: '',
+      });
+      expect(prompt).toContain('Before: On the left river bank');
+      expect(prompt).not.toContain('Page:');
+      expect(prompt).not.toContain('After:');
+    });
+
+    it('includes only the after field when page/before are empty', () => {
+      const prompt = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: '',
+        after: 'closed for the holidays',
+      });
+      expect(prompt).toContain('After: closed for the holidays');
+      expect(prompt).not.toContain('Page:');
+      expect(prompt).not.toContain('Before:');
+    });
+
+    it('omits whitespace-only structured fields', () => {
+      const prompt = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: '   ',
+        after: '\n\t',
+        pageContext: 'Loan FAQ',
+      });
+      expect(prompt).toContain('Page: Loan FAQ');
+      expect(prompt).not.toContain('Before:');
+      expect(prompt).not.toContain('After:');
+    });
+  });
+
+  describe('empty structured context', () => {
+    it('omits the context line when every field is empty', () => {
+      const prompt = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: '',
+        after: '',
+      });
+      expect(prompt).not.toContain('Context:');
+      expect(prompt).not.toContain('disambiguation');
+    });
+
+    it('matches a no-context call when every field is whitespace', () => {
+      const withEmpty = formatTranslateGemmaPrompt('Bank', 'en', 'fi', {
+        before: '   ',
+        after: '   ',
+        pageContext: '   ',
+      });
+      const withoutArg = formatTranslateGemmaPrompt('Bank', 'en', 'fi');
+      expect(withEmpty).toBe(withoutArg);
+    });
+  });
 });
 
 describe('prompt template validation', () => {


### PR DESCRIPTION
## Why

PR #527 (`feat: add contextual TranslateGemma prompts`) merged into `main` (squash commit 45c195f) while its branch coverage gate was red. The contextual-prompt feature added new branches that lacked tests, dropping repo-wide **branch coverage to 94.53%**, below the configured **95%** threshold in `vitest.shared.ts`. The `coverage` workflow on `main` is therefore failing.

This is a follow-up that adds real unit tests for the new code paths so the gate passes genuinely — the threshold is **not** lowered.

## What

Branch coverage restored to **95.07%** (3688/3879). Tests added:

- **translategemma**: structured / partial / empty / whitespace-only context objects, per-segment context arrays (single + batched input), `detectWebNN` support detection.
- **content/context**: `getSegmentTranslationContext` fallbacks — no block ancestor, hidden subtree, whitespace-only target, empty text nodes in the walker.
- **offscreen**: invalid lang-code validation, default-provider resolution, string `pageContext` forwarding.
- **message-routing**: `routeOffscreenMessage` type coercion for missing and unrecognized message types.

## Verification (local, against current main)

| Gate | Result |
|---|---|
| `validate:coverage` | branches 95.07% (statements 97.87, functions 98.2, lines 97.89) — passes |
| `tsc --noEmit` | clean |
| `eslint .` | clean |
| `prettier --check` (CI list) | clean |
| `vitest run` (full) | 5103 passed |

No production code changed — tests only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)