### PR TITLE
fix(ci): guard release Inject-Extension-ID against missing updates.xml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,13 @@ jobs:
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
         run: |
+          if [ ! -f updates.xml ]; then
+            echo "updates.xml not present in the repo — skipping extension-ID injection."
+            echo "This step targets a self-hosted Chrome auto-update manifest; the active"
+            echo "release path publishes via changesets/npm. Add an updates.xml template"
+            echo "with the YOUR_EXTENSION_ID placeholder to re-enable injection."
+            exit 0
+          fi
           escaped_id=$(printf '%s' "$EXTENSION_ID" | sed -e 's/[\/&\\]/\\&/g')
           sed -i "s/YOUR_EXTENSION_ID/${escaped_id}/g" updates.xml
       - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1 branch


### PR DESCRIPTION
## Context

With the OSV security-gate fixed (#545), the Release job finally executed past the gate — and immediately failed at 'Inject Extension ID' with 'sed: can't read updates.xml: No such file or directory' (exit 2). updates.xml exists nowhere in the repo (verified: fd -uu updates.xml = none). This step was latent — the security gate failed first for 3 weeks, so the release job never ran until now.

The step targets a self-hosted Chrome auto-update manifest, but the active release path publishes via changesets/npm (no self-hosted CRX is built/hosted here). Fabricating an updates.xml pointing nowhere would be wrong.

## Change
Guard the step: if updates.xml is absent, log why and exit 0, letting the real changesets release proceed. If an updates.xml template is added later, injection re-enables automatically.

## Acceptance Criteria
- [ ] TBE.REL.1 release job no longer fails on missing updates.xml
- [ ] TBE.REL.2 Inject step skips cleanly (exit 0) with an explanatory log when updates.xml absent
- [ ] TBE.REL.3 Release workflow reaches the changesets/action publish step

## Priority / ROI
P2 — value/cost: unblocks the Release pipeline's final job (latent since the feature was half-added) / ~10min.

## Note (blast radius — operator visibility)
This re-enables the changesets/action step that has been dead-by-failure. That is the designed behavior of a 'Release on push to main' workflow: changesets opens/merges a Version Packages PR and runs npm publish only when changesets are pending. If auto-publish-on-main is NOT desired, the trigger (push: branches:[main]) should change — separate from this fix.

## Rollback
Revert this commit (restores the unconditional sed; re-breaks the release job).