### PR TITLE
fix(ci): grant pull-requests write for changeset release PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   packages: write
+  pull-requests: write
 
 jobs:
   # Dependency-vulnerability backstop. ci.yml gates PRs on


### PR DESCRIPTION
## Context

After #545 (OSV gate) and #546 (Inject-step guard), the Release job reached the changeset release step and failed: HttpError Resource not accessible by integration when creating the Version Packages PR. The workflow permissions block listed only contents and packages, giving the token pull-requests none. The changeset release step needs pull-requests write to open the release PR. Repo setting already permits it (can_approve_pull_request_reviews=true); the workflow-scoped permission was the missing piece.

## Acceptance Criteria

- [ ] TBE.REL.4 release.yml permissions include pull-requests write
- [ ] TBE.REL.5 post-merge Release run opens the Version Packages PR without the Resource-not-accessible error
- [ ] TBE.REL.6 Release workflow conclusion is success on main

## Priority / ROI

P1 — final blocker to a fully-green Release pipeline, ~5min.

## Rollback

Revert (restores contents and packages only; re-breaks release PR creation).
