### PR TITLE
fix(ci): gate Dev Build self-host CRX steps on signing-key presence

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,19 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
+      - name: Detect CRX signing key
+        id: signing
+        env:
+          CRX_PRIVATE_KEY: ${{ secrets.CRX_PRIVATE_KEY }}
+        run: |
+          if [ -n "$CRX_PRIVATE_KEY" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::CRX_PRIVATE_KEY secret is not set - skipping self-hosted CRX sign + updates.xml commit. The extension build itself succeeded; only the opt-in self-host distribution path is skipped. Set CRX_PRIVATE_KEY (base64-encoded RSA key matching the Chrome Web Store extension ID) to enable it."
+          fi
       - name: Decode, sign, and clean
+        if: steps.signing.outputs.enabled == 'true'
         # TX-01: key.pem is removed via EXIT trap even if signing fails mid-step.
         # Previously rm was a separate step; a signing failure would leave key.pem
         # on disk and risk inclusion in any subsequent artifact upload.
@@ -63,6 +75,7 @@ jobs:
           # The old key is not revocable from GHA; only the CWS developer
           # dashboard controls which key is trusted for your extension ID.
       - name: Prepare update files
+        if: steps.signing.outputs.enabled == 'true'
         run: |
           printf '%s\n' \
             '<?xml version="1.0" encoding="UTF-8"?>' \
@@ -72,6 +85,7 @@ jobs:
             '  </app>' \
             '</gupdate>' > updates.xml
       - name: Commit update files
+        if: steps.signing.outputs.enabled == 'true'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"


### PR DESCRIPTION
## Context

With the OSV gate fixed (#545), Dev Build executed past it and failed at "Commit update files" with exit 128: pathspec ...crx did not match any files. Root cause: the CRX_PRIVATE_KEY secret is unset (the build log env dump showed it empty), so the sign step produced no .crx. Latent for 3 weeks because the OSV gate failed first.

The self-host CRX path (sign, generate updates.xml, commit binaries to main) is opt-in and needs the operator's extension signing key. It cannot be fabricated (must match the Chrome Web Store extension ID).

## Change

Add a "Detect CRX signing key" step and gate the three self-host steps on it:
- npm run build always runs (the real CI signal)
- when CRX_PRIVATE_KEY is present, full self-host distribution runs
- when absent, those steps skip with a notice explaining how to enable

## Acceptance Criteria

- [ ] TBE.DEV.1 Dev Build no longer fails when CRX_PRIVATE_KEY is unset
- [ ] TBE.DEV.2 npm run build still runs and gates the workflow
- [ ] TBE.DEV.3 a notice annotation explains the skip and how to enable self-host distribution
- [ ] TBE.DEV.4 Dev Build workflow conclusion is success on main

## Priority / ROI

P1 — clears the last red translate workflow honestly, ~10min.

## Operator action to fully enable self-host distribution

Set the CRX_PRIVATE_KEY repo secret (base64-encoded RSA key matching the extension ID). Until then, self-host CRX distribution stays off by design; the rest of CI is green.

## Rollback

Revert (restores unconditional sign+commit; re-breaks Dev Build while the secret is unset).
