### PR TITLE
fix(ci): gate npm publish on NPM_TOKEN + fix createGithubReleases input

### DIFF
--- a/.github/scripts/changesets-publish.sh
+++ b/.github/scripts/changesets-publish.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# changesets/action publish command for translate-by-mikko.
+#
+# Gates npm publish on the NPM_TOKEN secret:
+#   - NPM_TOKEN set   -> configure ~/.npmrc auth + npm publish
+#   - NPM_TOKEN unset -> skip with a ::notice:: (exit 0) so the release still
+#                        versions and creates the GitHub release instead of
+#                        failing with npm ENEEDAUTH.
+#
+# The previous `publish: npm publish` failed two ways: (1) ENEEDAUTH because no
+# ~/.npmrc auth was wired even when a token existed, and (2) hard-failed the
+# whole Release run when NPM_TOKEN was absent. This script fixes both.
+set -euo pipefail
+
+if [ -n "${NPM_TOKEN:-}" ]; then
+  echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "${HOME}/.npmrc"
+  npm publish
+else
+  echo "::notice::NPM_TOKEN not set - skipping npm publish. The version bump and GitHub release are still created. Set the NPM_TOKEN repo secret to publish translate-by-mikko to the npm registry."
+fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,14 @@ jobs:
           sed -i "s/YOUR_EXTENSION_ID/${escaped_id}/g" updates.xml
       - uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1 branch
         with:
-          publish: npm publish
-          createGithubRelease: true
+          # Gate npm publish on NPM_TOKEN: when the secret is set, publish to
+          # npm; when absent, skip with a notice (exit 0) so the release still
+          # versions + creates the GitHub release instead of failing ENEEDAUTH.
+          publish: bash .github/scripts/changesets-publish.sh
+          # NOTE: input is the plural 'createGithubReleases'. The previous
+          # 'createGithubRelease' (singular) was silently ignored by the action
+          # (logged 'Unexpected input'), so GitHub releases were never created.
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Context

After #548 merged (version 2.2.0), the Release changesets step failed at npm publish with ENEEDAUTH: (1) NPM_TOKEN is unset, and (2) even with a token, no ~/.npmrc auth was wired so npm publish could never authenticate. Separately, the action logged "Unexpected input createGithubRelease" — the input is the plural createGithubReleases, so GitHub releases were never created.

## Change

- publish now runs .github/scripts/changesets-publish.sh: wires ~/.npmrc from NPM_TOKEN and publishes when the secret is present; when absent, skips with a notice (exit 0) so the version bump and GitHub release still happen instead of a hard ENEEDAUTH failure.
- createGithubRelease becomes createGithubReleases (valid input; uses GITHUB_TOKEN, needs no operator secret).

## Acceptance Criteria

- [ ] TBE.PUB.1 Release run is green when NPM_TOKEN is unset (publish skipped with a notice)
- [ ] TBE.PUB.2 createGithubReleases input no longer triggers the Unexpected-input warning
- [ ] TBE.PUB.3 when NPM_TOKEN is set, the script wires ~/.npmrc and runs npm publish

## Priority / ROI

P1 — last red on the Release pipeline; makes it green honestly, ~10min.

## Operator action to actually publish to npm

Set the NPM_TOKEN repo secret. Until then npm publish is skipped by design (versioning + GitHub release still run). If you do NOT want npm publishing at all, say so and the publish input can be dropped entirely.

## Rollback

Revert (restores publish: npm publish + the createGithubRelease typo).
