### PR TITLE
fix(csp): allow Hugging Face model CDN host *.aws.cdn.hf.co

### DIFF
--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -49,7 +49,7 @@
     "assets/*",
     "chunks/*"
   ],
-  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.hf.co https://cdn-lfs-eu-1.hf.co https://cdn-lfs-ap-1.hf.co https://huggingface.co https://hf.co https://api.deepl.com https://api-free.deepl.com https://api.openai.com https://generativelanguage.googleapis.com https://api.anthropic.com;",
+  "content_security_policy": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.hf.co https://cdn-lfs-eu-1.hf.co https://cdn-lfs-ap-1.hf.co https://huggingface.co https://hf.co https://*.aws.cdn.hf.co https://api.deepl.com https://api-free.deepl.com https://api.openai.com https://generativelanguage.googleapis.com https://api.anthropic.com;",
   "browser_specific_settings": {
     "gecko": {
       "id": "translate@mikko.dev",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -81,6 +81,6 @@
     }
   ],
   "content_security_policy": {
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.hf.co https://cdn-lfs-eu-1.hf.co https://cdn-lfs-ap-1.hf.co https://huggingface.co https://hf.co https://*.xethub.hf.co https://cas-bridge.xethub.hf.co https://api.deepl.com https://api-free.deepl.com https://api.openai.com https://generativelanguage.googleapis.com https://api.anthropic.com https://cdn.jsdelivr.net https://tessdata.projectnaptha.com;"
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; connect-src 'self' https://cdn-lfs.huggingface.co https://cdn-lfs-us-1.hf.co https://cdn-lfs-eu-1.hf.co https://cdn-lfs-ap-1.hf.co https://huggingface.co https://hf.co https://*.aws.cdn.hf.co https://*.xethub.hf.co https://cas-bridge.xethub.hf.co https://api.deepl.com https://api-free.deepl.com https://api.openai.com https://generativelanguage.googleapis.com https://api.anthropic.com https://cdn.jsdelivr.net https://tessdata.projectnaptha.com;"
   }
 }


### PR DESCRIPTION
Add https://*.aws.cdn.hf.co to connect-src in src/manifest.json and src/manifest.firefox.json. HF migrated its Xet/LFS model CDN to *.aws.cdn.hf.co (e.g. us.aws.cdn.hf.co); that host was not allowlisted, so the offscreen model download is CSP-blocked (TypeError: Failed to fetch), breaking model loading and failing e2e/csp-model-loading.spec.ts (which blocks PRs like #559 from auto-merging). Scoped wildcard, passes the CSP security test. 🤖 Generated with Claude Code