### PR TITLE
docs: drop false encryption claims, document screenshot OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Built-in browser translation (Chrome, Safari, Firefox) works well for many pages
 - **Smart batching and caching** -- identical strings translated once and reused. Hidden elements skipped. Session cache minimizes repeat API calls.
 - **Auto-translate** -- optionally translate pages on load.
 - **Source language auto-detection** -- browser-native detectors first, with offline trigram/script fallback when needed.
+- **Screenshot translation** -- drag a rectangle over any part of the page, and the extension captures that region, reads the text out of it with Tesseract.js (optical character recognition, running in the extension itself), translates it, and shows the result in an overlay under the selection. The overlay has a close button and disappears on its own after 30 seconds. It runs from the "Screenshot translate mode" command, which ships without a default key: assign one at `chrome://extensions/shortcuts`.
 - **Keyboard shortcuts** -- `Ctrl+Shift+P` translate page, `Ctrl+Shift+T` translate selection, `Ctrl+Shift+U` undo.
 - **Diagnostics dashboard** -- live usage metrics, cost tracking, latency histogram.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -19,7 +19,7 @@ This document provides comprehensive API documentation for the Translate by Mikk
 
 ### Configuration Manager (`ConfigManager`)
 
-Centralized configuration management with encryption support and validation.
+Centralized configuration management with validation.
 
 #### Interface Definition
 
@@ -51,10 +51,10 @@ const uiPrefs = await configManager.get('ui', { theme: 'modern' });
 
 **`set<T>(key: string, value: T): Promise<void>`**
 
-Sets a configuration value with automatic validation and encryption for sensitive data.
+Sets a configuration value with automatic validation. Values are stored as given; there is no encryption layer.
 
 ```javascript
-// Store API key (automatically encrypted)
+// Store API key (stored in plain text in extension storage)
 await configManager.set('apiKey', 'sk-1234567890abcdef');
 
 // Store provider configuration

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -87,7 +87,7 @@ DOM Update (visible to user)
 
 ## Security Model
 
-- **API keys** - AES-256-GCM encrypted at rest
+- **API keys** - stored in plain text in extension storage (`browser.storage.local`); no encryption at rest
 - **Transport** - TLS 1.3+ for all provider communications
 - **Permissions** - Minimal required: storage, activeTab, scripting
 - **CSP** - Strict Content Security Policy with WASM support

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -8,7 +8,6 @@
 ### P0: Product Differentiators Still Open
 
 - [ ] **Contextual page-semantic translation** — Track in Linear as MIK-3469. Inject bounded page/section context into TranslateGemma prompts without changing the model. `formatTranslateGemmaPrompt()` remains a prompt-formatting seam; no shipped page-semantic prompt path was found in the current repo.
-- [ ] **Screenshot OCR translation overlay** — Track in Linear as MIK-3471. Capture/crop/OCR plumbing exists, but the user-facing region selection, translation, positioned overlay, and cleanup/undo path still need to be wired.
 
 ### P1: Performance Work Still Open
 
@@ -30,6 +29,7 @@
 - [x] **IndexedDB translation memory** — Shipped. `src/core/translation-cache.ts` implements a 100MB IndexedDB-backed LRU cache with stats and eviction.
 - [x] **Inline editing + correction learning** — Shipped. `src/content/correction.ts` makes translated elements editable and saves corrections via `addCorrection`.
 - [x] **PDF layout-preserving translation** — Shipped. `src/content/pdf-translator.ts` uses pdf.js text spans, groups them, translates them, and renders a toggleable layout overlay.
+- [x] **Screenshot OCR translation overlay** — Shipped (MIK-3471). `src/content/screenshot-ocr.ts` draws the region selection, sends `captureScreenshot` and `ocrImage` to the background, translates the recognized text, and shows a positioned overlay with a close button and a 30-second auto-remove. Entry point is the `screenshot-translate` command in `src/manifest.json`, routed by `src/background/shared/ui-event-handlers.ts`.
 - [x] **Video subtitle translation** — Shipped. `src/content/subtitle-translator.ts` supports standard TextTrack cues and YouTube caption segments.
 - [x] **SharedWorker migration** — Killed. The original premise is superseded: the service worker/offscreen architecture already gives shared cache/model behavior, and content scripts cannot reliably connect to an extension SharedWorker from page origin.
 
@@ -43,7 +43,7 @@
 - IndexedDB cache: `src/core/translation-cache.ts`
 - Correction learning: `src/content/correction.ts`
 - PDF translation: `src/content/pdf-translator.ts`
-- Screenshot/OCR plumbing: `src/background/shared/media-handlers.ts`, `src/offscreen/offscreen.ts`
+- Screenshot/OCR plumbing: `src/background/shared/media-handlers.ts`, `src/offscreen/offscreen.ts`, `src/content/screenshot-ocr.ts`
 - Subtitle translation: `src/content/subtitle-translator.ts`
 - Runtime acceleration checks: `src/offscreen/offscreen.ts`, `src/shared/provider-options.ts`
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -199,7 +199,7 @@ interface ExtensionResponse<T = any> {
 interface ProviderConfig {
   id: string;                    // Unique identifier
   name: string;                  // Human readable name
-  apiKey: string;               // Encrypted API key
+  apiKey: string;               // API key (stored in plain text)
   apiEndpoint: string;          // Base URL for API
   model: string;                // Default model
   models: string[];             // Available models
@@ -220,7 +220,7 @@ interface ProviderConfig {
 ### Threat Model
 
 **Assets Protected:**
-- User's translation API keys (stored encrypted)
+- User's translation API keys (stored in plain text in extension storage)
 - Personal data in web page content  
 - User browsing patterns and preferences
 - Translation history and cached results
@@ -243,14 +243,8 @@ Input Validation Layer:
 │ • API responses │    │ • Encoding      │    │ • Range bounds  │
 └─────────────────┘    └─────────────────┘    └─────────────────┘
 
-Encryption Layer:
-┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
-│   Plaintext     │───▶│   AES-256-GCM   │───▶│   Ciphertext    │
-│                 │    │                 │    │                 │
-│ • API keys      │    │ • Key derivation│    │ • Storage safe │
-│ • Preferences   │    │ • IV generation │    │ • Tamper proof  │
-│ • Cache data    │    │ • Auth tags     │    │ • Forward sec   │
-└─────────────────┘    └─────────────────┘    └─────────────────┘
+Encryption Layer: none. API keys, preferences, and cached translations are
+written to extension storage as plain text.
 
 Communication Security:
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
@@ -286,9 +280,7 @@ connect-src https://*.aliyuncs.com https://api.openai.com https://api.deepl.com;
 ### Data Protection
 
 **Encryption at Rest:**
-- API keys: AES-256-GCM with PBKDF2-derived keys
-- Configuration: Selective encryption of sensitive fields
-- Cache: Plaintext (non-sensitive translation results)
+- None. API keys, configuration, and cached translations are stored as plain text in extension storage, which is readable by anyone with access to the browser profile.
 
 **Encryption in Transit:**
 - TLS 1.3+ for all API communications


### PR DESCRIPTION
Two documentation statements did not match the code. Both were re-verified at source before editing.

## 1. API keys are not encrypted at rest (false claim removed)

Docs said `**API keys** - AES-256-GCM encrypted at rest` (docs/ARCHITECTURE.md:90) and that config values are "automatically encrypted" (docs/API.md:54,57), with a matching AES-256-GCM diagram and "Encryption at Rest" section in docs/architecture/README.md.

What the code does: a provider key goes from `setApiKey` (src/providers/deepl.ts:94-96) through `persist` (src/providers/cloud-provider.ts:148) to `strictStorageSet` (src/core/storage.ts:68-74), which calls `browserAPI.storage.local.set(items)` on the value as given. `rg "crypto\.subtle|AES|encrypt|decrypt" src/` returns 0 matches across 205 files.

Docs now say the keys are stored in plain text in extension storage.

## 2. Screenshot OCR translation ships (undocumented capability added)

docs/IMPROVEMENT_PLAN.md:11 listed it as an open P0 whose "region selection, translation, positioned overlay, and cleanup/undo path still need to be wired", and README.md had no mention of it at all.

What the code does: `enterScreenshotMode` (src/content/screenshot-ocr.ts:33) draws the selection rectangle; on mouseup (src/content/screenshot-ocr.ts:114-171) it sends `captureScreenshot` and `ocrImage` to the background, then `translate`, then renders a positioned overlay with a close button and a 30-second auto-remove (src/content/screenshot-ocr.ts:231-232). OCR is Tesseract.js in the offscreen document (src/core/ocr-service.ts:6, src/offscreen/offscreen.ts:77). The entry point is the `screenshot-translate` command (src/manifest.json:73, src/manifest.firefox.json:44), routed to the content script at src/background/shared/ui-event-handlers.ts:59-62 and handled at src/content/index.ts:630. That command ships with no default key, so the README says to assign one at chrome://extensions/shortcuts.

## Not changed

- docs/FUTURE_ARCHITECTURE.md:583 mentions encrypted storage inside an explicitly future/vision design doc, not a claim about current behavior.
- docs/DEVELOPMENT.md:931-936 is a jest sample test for a `ConfigManager` class that does not exist in src/ at all; that section is drift of a different kind and is out of scope here.

Docs-only change. `git diff --check` clean. The three prettier warnings on the touched files are pre-existing on main and were left alone to keep the diff minimal.